### PR TITLE
Building IO routines for complex image objects

### DIFF
--- a/pyfibre/io/object_io.py
+++ b/pyfibre/io/object_io.py
@@ -1,4 +1,43 @@
-from pyfibre.utilities import save_pickle, load_pickle
+import numpy as np
+from networkx.readwrite import node_link_graph
+
+from pyfibre.model.objects.base_graph_segment import BaseGraphSegment
+from pyfibre.utilities import (
+    save_pickle, load_pickle, save_json, load_json)
+
+
+def save_base_graph_segment(object, file_name, file_type=None):
+
+    data = object.__getstate__()
+
+    try:
+        save_json(data, f"{file_name}.json")
+    except IOError as e:
+        raise IOError(
+            f"Cannot save to file {file_name}.json"
+        ) from e
+
+
+def load_base_graph_segment(file_name, file_type=None):
+    """Loads pickled image objects"""
+
+    if file_type is not None:
+        file_name = '_'.join([file_name, file_type])
+
+    try:
+        data = load_json(f"{file_name}.json")
+
+    except IOError as e:
+        raise IOError(
+            f"Cannot read file {file_name}.json"
+        ) from e
+
+    for coord in data['graph']['nodes']:
+        coord['xy'] = np.array(coord['xy'])
+
+    data['graph'] = node_link_graph(data['graph'])
+
+    return BaseGraphSegment(**data)
 
 
 def save_objects(objects, file_name, file_type=None):

--- a/pyfibre/io/object_io.py
+++ b/pyfibre/io/object_io.py
@@ -2,42 +2,89 @@ import numpy as np
 from networkx.readwrite import node_link_graph
 
 from pyfibre.model.objects.base_graph_segment import BaseGraphSegment
+from pyfibre.model.objects.fibre_network import FibreNetwork
 from pyfibre.utilities import (
     save_pickle, load_pickle, save_json, load_json)
 
 
-def save_base_graph_segment(object, file_name, file_type=None):
+def get_networkx_graph(data):
+    """Transform JSON serialised data into a
+    networkx Graph object"""
 
-    data = object.__getstate__()
+    for coord in data['nodes']:
+        coord['xy'] = np.array(coord['xy'])
 
-    try:
-        save_json(data, f"{file_name}.json")
-    except IOError as e:
-        raise IOError(
-            f"Cannot save to file {file_name}.json"
-        ) from e
+    return node_link_graph(data)
 
 
-def load_base_graph_segment(file_name, file_type=None):
+def save_base_graph_segment(graph_segment, file_name, file_type=None):
+
+    if file_type is not None:
+        file_name = '_'.join([file_name, file_type])
+
+    data = graph_segment.__getstate__()
+
+    save_json(data, file_name)
+
+
+def load_base_graph_segment(file_name, file_type=None, klass=BaseGraphSegment):
     """Loads pickled image objects"""
 
     if file_type is not None:
         file_name = '_'.join([file_name, file_type])
 
-    try:
-        data = load_json(f"{file_name}.json")
+    data = load_json(file_name)
 
-    except IOError as e:
-        raise IOError(
-            f"Cannot read file {file_name}.json"
-        ) from e
+    data['graph'] = get_networkx_graph(data['graph'])
 
-    for coord in data['graph']['nodes']:
-        coord['xy'] = np.array(coord['xy'])
+    return klass(**data)
 
-    data['graph'] = node_link_graph(data['graph'])
 
-    return BaseGraphSegment(**data)
+def save_base_graph_segments(graph_segments, file_name, file_type=None):
+
+    if file_type is not None:
+        file_name = '_'.join([file_name, file_type])
+    else:
+        file_type = 'graph_segment'
+
+    data = {
+        file_type : [
+            graph_segment.__getstate__()
+            for graph_segment in graph_segments]
+    }
+
+    save_json(data, file_name)
+
+
+def load_base_graph_segments(file_name, file_type=None, klass=BaseGraphSegment):
+
+    if file_type is not None:
+        file_name = '_'.join([file_name, file_type])
+    else:
+        file_type = 'graph_segment'
+
+    data = load_json(file_name)
+
+    for graph_segment in data[file_type]:
+        graph_segment['graph'] = get_networkx_graph(
+            graph_segment['graph'])
+
+    graph_segments = [
+        klass(**kwargs) for kwargs in data[file_type]
+    ]
+
+    return graph_segments
+
+
+def save_fibre_networks(fibre_networks, file_name):
+    """Save a list of FibreNetwork instances"""
+    save_base_graph_segments(fibre_networks, file_name, 'fibre_networks')
+
+
+def load_fibre_networks(file_name):
+    """Load a list of FibreNetwork instances"""
+    return load_base_graph_segments(
+        file_name, 'fibre_networks', FibreNetwork)
 
 
 def save_objects(objects, file_name, file_type=None):
@@ -60,7 +107,6 @@ def load_objects(file_name, file_type=None):
     if file_type is not None:
         file_name = '_'.join([file_name, file_type])
 
-    print(file_name)
     try:
         objects = load_pickle(f"{file_name}.pkl")
         return objects

--- a/pyfibre/io/tests/test_object_io.py
+++ b/pyfibre/io/tests/test_object_io.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+import os
+
+from pyfibre.io.object_io import (
+    save_base_graph_segment, load_base_graph_segment)
+from pyfibre.model.objects.base_graph_segment import (
+    BaseGraphSegment
+)
+from pyfibre.tests.probe_classes import generate_probe_graph
+
+
+class TestObjectIO(TestCase):
+
+    def setUp(self):
+
+        self.graph = generate_probe_graph()
+        self.graph_segment = BaseGraphSegment(graph=self.graph)
+
+    def test_save_load_base_graph_segment(self):
+
+        try:
+            save_base_graph_segment(self.graph_segment, 'test_json')
+            self.assertTrue(os.path.exists('test_json.json'))
+
+            test_segment = load_base_graph_segment('test_json')
+
+            self.assertIsInstance(test_segment, BaseGraphSegment)
+            self.assertEqual(
+                self.graph.number_of_nodes(),
+                test_segment.graph.number_of_nodes()
+            )
+
+            self.assertEqual(
+                self.graph.number_of_edges(),
+                test_segment.graph.number_of_edges()
+            )
+
+        finally:
+            if os.path.exists('test_json.json'):
+                os.remove('test_json.json')

--- a/pyfibre/io/tests/test_object_io.py
+++ b/pyfibre/io/tests/test_object_io.py
@@ -1,8 +1,13 @@
 from unittest import TestCase
 import os
 
+import numpy as np
+import networkx as nx
+
 from pyfibre.io.object_io import (
-    save_base_graph_segment, load_base_graph_segment)
+    get_networkx_graph,
+    save_base_graph_segment, load_base_graph_segment,
+    save_base_graph_segments, load_base_graph_segments)
 from pyfibre.model.objects.base_graph_segment import (
     BaseGraphSegment
 )
@@ -15,6 +20,25 @@ class TestObjectIO(TestCase):
 
         self.graph = generate_probe_graph()
         self.graph_segment = BaseGraphSegment(graph=self.graph)
+
+    def test_get_networkx_graph(self):
+
+        data = {
+            'directed': False,
+            'graph': {},
+            'links': [],
+            'multigraph': False,
+            'nodes': [{'xy': [0, 0], 'id': 2},
+                      {'xy': [1, 1], 'id': 3},
+                      {'xy': [2, 2], 'id': 4},
+                      {'xy': [2, 3], 'id': 5}]
+        }
+
+        graph = get_networkx_graph(data)
+
+        self.assertIsInstance(graph, nx.Graph)
+        self.assertEqual(4, graph.number_of_nodes())
+        self.assertIsInstance(graph.nodes[2]['xy'], np.ndarray)
 
     def test_save_load_base_graph_segment(self):
 
@@ -33,6 +57,32 @@ class TestObjectIO(TestCase):
             self.assertEqual(
                 self.graph.number_of_edges(),
                 test_segment.graph.number_of_edges()
+            )
+
+        finally:
+            if os.path.exists('test_json.json'):
+                os.remove('test_json.json')
+
+    def test_save_load_base_graph_segments(self):
+
+        try:
+            save_base_graph_segments(
+                [self.graph_segment, self.graph_segment],
+                'test_json')
+            self.assertTrue(os.path.exists('test_json.json'))
+
+            test_segments = load_base_graph_segments('test_json')
+
+            self.assertEqual(2, len(test_segments))
+            self.assertIsInstance(
+                test_segments[0], BaseGraphSegment)
+            self.assertEqual(
+                self.graph.number_of_nodes(),
+                test_segments[0].graph.number_of_nodes()
+            )
+            self.assertEqual(
+                self.graph.number_of_edges(),
+                test_segments[0].graph.number_of_edges()
             )
 
         finally:

--- a/pyfibre/io/tests/test_utils.py
+++ b/pyfibre/io/tests/test_utils.py
@@ -2,7 +2,8 @@ from unittest import mock, TestCase
 import os
 
 from .. utils import (
-    parse_files, parse_file_path, pop_dunder_recursive)
+    parse_files, parse_file_path, pop_under_recursive,
+    pop_dunder_recursive)
 
 source_dir = os.path.dirname(os.path.realpath(__file__))
 pyfibre_dir = os.path.dirname(os.path.dirname(source_dir))
@@ -16,6 +17,18 @@ class TestUtils(TestCase):
         )
         self.directory = os.path.dirname(self.file_name)
         self.key = 'shg'
+        self.test_dict = {
+            '__traits_version__': '4.6.0',
+            'some_important_data':
+                {'__traits_version__': '4.6.0', 'value': 10},
+            '_some_private_data':
+                {'__instance_traits__': ['yes', 'some']},
+            '___':
+                {'__': 'a', 'foo': 'bar'},
+            'list_of_dicts': [
+                {'__bad_key__': 'bad', 'good_key': 'good'},
+                {'also_good_key': 'good'}]
+        }
 
     def test_parse_file_path(self):
 
@@ -42,22 +55,21 @@ class TestUtils(TestCase):
                                   key=self.key)
         self.assertEqual(input_files[0], self.file_name)
 
-    def test_dunder_recursive(self):
-        test_dict = {
-            '__traits_version__': '4.6.0',
-            'some_important_data':
-                {'__traits_version__': '4.6.0', 'value': 10},
-            '_some_private_data':
-                {'__instance_traits__': ['yes', 'some']},
-            '___':
-                {'__': 'a', 'foo': 'bar'},
+    def test_under_recursive(self):
+
+        expected = {
+            'some_important_data': {'value': 10},
             'list_of_dicts': [
-                {'__bad_key__': 'bad', 'good_key': 'good'},
+                {'good_key': 'good'},
                 {'also_good_key': 'good'}]
         }
+        self.assertEqual(pop_under_recursive(self.test_dict), expected)
+
+    def test_dunder_recursive(self):
+
         expected = {'some_important_data': {'value': 10},
                     '_some_private_data': {},
                     'list_of_dicts': [{'good_key': 'good'},
                                       {'also_good_key': 'good'}]
                     }
-        self.assertEqual(pop_dunder_recursive(test_dict), expected)
+        self.assertEqual(pop_dunder_recursive(self.test_dict), expected)

--- a/pyfibre/io/tests/test_utils.py
+++ b/pyfibre/io/tests/test_utils.py
@@ -1,6 +1,8 @@
 from unittest import mock, TestCase
 import os
-from pyfibre.io.utils import parse_files, parse_file_path
+
+from .. utils import (
+    parse_files, parse_file_path, pop_dunder_recursive)
 
 source_dir = os.path.dirname(os.path.realpath(__file__))
 pyfibre_dir = os.path.dirname(os.path.dirname(source_dir))
@@ -39,3 +41,23 @@ class TestUtils(TestCase):
         input_files = parse_files(directory=self.directory,
                                   key=self.key)
         self.assertEqual(input_files[0], self.file_name)
+
+    def test_dunder_recursive(self):
+        test_dict = {
+            '__traits_version__': '4.6.0',
+            'some_important_data':
+                {'__traits_version__': '4.6.0', 'value': 10},
+            '_some_private_data':
+                {'__instance_traits__': ['yes', 'some']},
+            '___':
+                {'__': 'a', 'foo': 'bar'},
+            'list_of_dicts': [
+                {'__bad_key__': 'bad', 'good_key': 'good'},
+                {'also_good_key': 'good'}]
+        }
+        expected = {'some_important_data': {'value': 10},
+                    '_some_private_data': {},
+                    'list_of_dicts': [{'good_key': 'good'},
+                                      {'also_good_key': 'good'}]
+                    }
+        self.assertEqual(pop_dunder_recursive(test_dict), expected)

--- a/pyfibre/io/utils.py
+++ b/pyfibre/io/utils.py
@@ -43,3 +43,47 @@ def parse_file_path(file_path):
         directory = file_path
 
     return file_name, directory
+
+
+def pop_recursive(dictionary, remove_key):
+    """Recursively remove a named key from dictionary and any contained
+    dictionaries."""
+    try:
+        dictionary.pop(remove_key)
+    except KeyError:
+        pass
+
+    for key, value in dictionary.items():
+        # If remove_key is in the dict, remove it
+        if isinstance(value, dict):
+            pop_recursive(value, remove_key)
+        # If we have a non-dict iterable which contains a dict,
+        # call pop.(remove_key) from that as well
+        elif isinstance(value, (tuple, list)):
+            for element in value:
+                if isinstance(element, dict):
+                    pop_recursive(element, remove_key)
+
+    return dictionary
+
+
+def pop_dunder_recursive(dictionary):
+    """ Recursively removes all dunder keys from a nested dictionary. """
+    keys = [key for key in dictionary.keys()]
+    for key in keys:
+        if key.startswith('__') and key.endswith('__'):
+            dictionary.pop(key)
+
+    for key, value in dictionary.items():
+        # Check subdicts for dunder keys
+        if isinstance(value, dict):
+            pop_dunder_recursive(value)
+        # If we have a non-dict iterable which contains a dict,
+        # remove dunder keys from that too
+        elif isinstance(value, (tuple, list)):
+            for element in value:
+                if isinstance(element, dict):
+                    pop_dunder_recursive(element)
+
+    return dictionary
+

--- a/pyfibre/io/utils.py
+++ b/pyfibre/io/utils.py
@@ -45,45 +45,52 @@ def parse_file_path(file_path):
     return file_name, directory
 
 
-def pop_recursive(dictionary, remove_key):
+def remove_under(dictionary):
+    keys = [key for key in dictionary.keys()]
+    for key in keys:
+        if key.startswith('_'):
+            dictionary.pop(key)
+
+
+def remove_dunder(dictionary):
+
+    keys = [key for key in dictionary.keys()]
+    for key in keys:
+        if key.startswith('__') and key.endswith('__'):
+            dictionary.pop(key)
+
+
+def pop_recursive(dictionary, pop_func):
     """Recursively remove a named key from dictionary and any contained
     dictionaries."""
-    try:
-        dictionary.pop(remove_key)
-    except KeyError:
-        pass
+
+    pop_func(dictionary)
 
     for key, value in dictionary.items():
         # If remove_key is in the dict, remove it
         if isinstance(value, dict):
-            pop_recursive(value, remove_key)
+            pop_recursive(value, pop_func)
         # If we have a non-dict iterable which contains a dict,
         # call pop.(remove_key) from that as well
         elif isinstance(value, (tuple, list)):
             for element in value:
                 if isinstance(element, dict):
-                    pop_recursive(element, remove_key)
+                    pop_recursive(element, pop_func)
+
+    return dictionary
+
+
+def pop_under_recursive(dictionary):
+    """Recursively removes all under keys from a nested dictionary. """
+
+    pop_recursive(dictionary, remove_under)
 
     return dictionary
 
 
 def pop_dunder_recursive(dictionary):
     """ Recursively removes all dunder keys from a nested dictionary. """
-    keys = [key for key in dictionary.keys()]
-    for key in keys:
-        if key.startswith('__') and key.endswith('__'):
-            dictionary.pop(key)
 
-    for key, value in dictionary.items():
-        # Check subdicts for dunder keys
-        if isinstance(value, dict):
-            pop_dunder_recursive(value)
-        # If we have a non-dict iterable which contains a dict,
-        # remove dunder keys from that too
-        elif isinstance(value, (tuple, list)):
-            for element in value:
-                if isinstance(element, dict):
-                    pop_dunder_recursive(element)
+    pop_recursive(dictionary, remove_dunder)
 
     return dictionary
-

--- a/pyfibre/model/image_analysis.py
+++ b/pyfibre/model/image_analysis.py
@@ -16,7 +16,9 @@ from pyfibre.model.tools.figures import (
 )
 from pyfibre.model.tools.preprocessing import nl_means
 from pyfibre.io.segment_io import load_segment, save_segment
-from pyfibre.io.object_io import save_objects, load_objects
+from pyfibre.io.object_io import (
+    save_fibre_networks, load_fibre_networks,
+    save_objects, load_objects)
 from pyfibre.io.network_io import save_network, load_network
 from pyfibre.io.database_io import save_database, load_database
 
@@ -145,7 +147,7 @@ def image_analysis(multi_image, prefix, scale=1.25,
 
         end_seg = time.time()
 
-        save_objects(fibre_networks, filename, "fibre_networks")
+        save_fibre_networks(fibre_networks, filename)
         save_objects(cells, filename, 'cells')
 
         logger.info(f"TOTAL SEGMENTATION TIME = {round(end_seg - start_seg, 3)} s")
@@ -155,7 +157,7 @@ def image_analysis(multi_image, prefix, scale=1.25,
         start_met = time.time()
 
         # Load networks and segments"
-        fibre_networks = load_objects(filename, "fibre_networks")
+        fibre_networks = load_fibre_networks(filename)
         cells = load_objects(filename, "cells")
 
         global_dataframe, dataframes = metric_analysis(
@@ -175,7 +177,7 @@ def image_analysis(multi_image, prefix, scale=1.25,
 
         start_fig = time.time()
 
-        fibre_networks = load_objects(filename, "fibre_networks")
+        fibre_networks = load_fibre_networks(filename)
         cells = load_objects(filename, "cells")
 
         fibre_segments = [fibre_network.segment for fibre_network in fibre_networks]

--- a/pyfibre/model/objects/base_graph_segment.py
+++ b/pyfibre/model/objects/base_graph_segment.py
@@ -1,3 +1,6 @@
+from networkx.readwrite.json_graph import node_link_data
+
+from pyfibre.io.utils import pop_under_recursive
 from pyfibre.model.tools.convertors import networks_to_segments
 from pyfibre.model.tools.fibre_utilities import get_node_coord_array
 
@@ -9,11 +12,24 @@ class BaseGraphSegment:
     def __init__(self, graph=None, image=None):
 
         self.graph = graph
+        self.image = image
+
         self._area_threshold = 64
         self._iterations = 2
         self._sigma = 0.5
 
-        self.image = image
+    def __getstate__(self):
+        """Return the object state in a form that can be
+        serialised as a JSON file"""
+        status = pop_under_recursive(self.__dict__)
+
+        graph = node_link_data(status['graph'])
+        for coord in graph['nodes']:
+            coord['xy'] = coord['xy'].tolist()
+
+        status['graph'] = graph
+
+        return status
 
     @property
     def node_list(self):

--- a/pyfibre/model/objects/base_graph_segment.py
+++ b/pyfibre/model/objects/base_graph_segment.py
@@ -1,3 +1,5 @@
+import copy
+
 from networkx.readwrite.json_graph import node_link_data
 
 from pyfibre.io.utils import pop_under_recursive
@@ -21,9 +23,10 @@ class BaseGraphSegment:
     def __getstate__(self):
         """Return the object state in a form that can be
         serialised as a JSON file"""
-        status = pop_under_recursive(self.__dict__)
+        status = pop_under_recursive(copy.copy(self.__dict__))
 
         graph = node_link_data(status['graph'])
+
         for coord in graph['nodes']:
             coord['xy'] = coord['xy'].tolist()
 

--- a/pyfibre/model/objects/tests/test_base_graph_segment.py
+++ b/pyfibre/model/objects/tests/test_base_graph_segment.py
@@ -15,6 +15,29 @@ class TestBaseGraphSegment(TestCase):
         self.graph = generate_probe_graph()
         self.graph_segment = BaseGraphSegment(graph=self.graph)
 
+    def test__getstate__(self):
+        status = self.graph_segment.__getstate__()
+
+        self.assertListEqual(
+            ['graph', 'image'],
+            list(status.keys())
+        )
+
+        self.assertDictEqual(
+            status['graph'],
+            {'directed': False,
+             'graph': {},
+             'links': [{'r': 1.4142135623730951, 'source': 2, 'target': 3},
+                       {'r': 1.4142135623730951, 'source': 3, 'target': 4},
+                       {'r': 1, 'source': 4, 'target': 5}],
+             'multigraph': False,
+             'nodes': [{'xy': [0, 0], 'id': 2},
+                       {'xy': [1, 1], 'id': 3},
+                       {'xy': [2, 2], 'id': 4},
+                       {'xy': [2, 3], 'id': 5}]
+             }
+        )
+
     def test_network_init(self):
 
         self.assertEqual(4, self.graph_segment.number_of_nodes)

--- a/pyfibre/model/objects/tests/test_fibre.py
+++ b/pyfibre/model/objects/tests/test_fibre.py
@@ -14,6 +14,16 @@ class TestFibre(TestCase):
 
         self.graph = generate_probe_graph()
 
+    def test__getstate__(self):
+        fibre = Fibre(graph=self.graph)
+
+        status = fibre.__getstate__()
+
+        self.assertListEqual(
+            ['graph', 'image', 'growing'],
+            list(status.keys())
+        )
+
     def test_node_list_init(self):
 
         fibre = Fibre(nodes=[2, 3, 4, 5],

--- a/pyfibre/model/objects/tests/test_fibre_network.py
+++ b/pyfibre/model/objects/tests/test_fibre_network.py
@@ -15,6 +15,15 @@ class TestNetwork(TestCase):
         self.graph = generate_probe_graph()
         self.network = FibreNetwork(graph=self.graph)
 
+    def test__getstate__(self):
+
+        status = self.network.__getstate__()
+
+        self.assertListEqual(
+            ['graph', 'image'],
+            list(status.keys())
+        )
+
     def test_fibres(self):
 
         fibres = self.network.fibres

--- a/pyfibre/utilities.py
+++ b/pyfibre/utilities.py
@@ -8,6 +8,7 @@ Created on: 01/11/2015
 Last Modified: 12/04/2018
 """
 import pickle
+import json
 
 import numpy as np
 
@@ -160,6 +161,23 @@ def load_pickle(file_name):
         object_ = pickle.load(infile)
 
     return object_
+
+
+def save_json(data, file_name):
+    """Saves data as JSON file"""
+
+    with open(file_name, 'w') as outfile:
+        json.dump(data, outfile, indent=4)
+
+
+def load_json(file_name):
+    """Loads JSON file as data"""
+
+    with open(file_name, 'r') as infile:
+        data = json.load(infile)
+
+    return data
+
 
 
 def dict_extract(dictionary, keys):

--- a/pyfibre/utilities.py
+++ b/pyfibre/utilities.py
@@ -166,18 +166,27 @@ def load_pickle(file_name):
 def save_json(data, file_name):
     """Saves data as JSON file"""
 
-    with open(file_name, 'w') as outfile:
-        json.dump(data, outfile, indent=4)
+    try:
+        with open(f"{file_name}.json", 'w') as outfile:
+            json.dump(data, outfile, indent=4)
+    except IOError as e:
+        raise IOError(
+            f"Cannot save to file {file_name}.json"
+        ) from e
 
 
 def load_json(file_name):
     """Loads JSON file as data"""
 
-    with open(file_name, 'r') as infile:
-        data = json.load(infile)
+    try:
+        with open(f"{file_name}.json", 'r') as infile:
+            data = json.load(infile)
+    except IOError as e:
+        raise IOError(
+            f"Cannot read file {file_name}.json"
+        ) from e
 
     return data
-
 
 
 def dict_extract(dictionary, keys):


### PR DESCRIPTION
This repo contributes routines to save and load mixed `networkx` and `scikit-image` objects

The `BaseGraphSegment` class has been updated with load and save routines that can serialise instances to JSON files.

These have also been extended to lists of `BaseGraphSegment` subclasses, such as `FibreSegment`