### PR TITLE
ENH: Update of UI after run is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PyFibre
 
+[![Build Status](https://github.com/franklongford/PyFibre/workflows/Build/badge.svg)](https://github.com/franklongford/PyFibre/actions)
+
 PyFibre is an open source image analysis toolkit for fibrous tissue that can be run either in a terminal or GUI. It is designed to make the quantification of fibrous tissue automated, standardised and efficient whilst remaining as transparent as possible for non-technical users.
  
 ![PyFibre logo](pyfibre/gui/images/icon.ico)

--- a/pyfibre/gui/file_display_pane.py
+++ b/pyfibre/gui/file_display_pane.py
@@ -181,7 +181,7 @@ class FileDisplayPane(TraitsDockPane):
                 table_row = TableRow(
                     name=key,
                     _dictionary=data)
-                if table_row.shg:
+                if table_row.shg and table_row.pl:
                     self.file_table.append(table_row)
 
     def view_selected_row(self, selected_rows):

--- a/pyfibre/gui/file_display_pane.py
+++ b/pyfibre/gui/file_display_pane.py
@@ -3,7 +3,7 @@ from pyface.api import ImageResource
 
 from traits.api import (
     HasTraits, List, Unicode, Button, File, Dict,
-    Bool, Int, Property
+    Bool, Int, Property, Str
 )
 from traitsui.api import (
     View, Item, Group, TableEditor, ObjectColumn,
@@ -24,7 +24,7 @@ class TableRow(HasTraits):
 
     name = Unicode()
 
-    _dictionary = Dict()
+    _dictionary = Dict(Str, File)
 
     shg = Property(Bool, depends_on='_dictionary')
 
@@ -101,8 +101,7 @@ class FileDisplayPane(TraitsDockPane):
                              resize_mode="fixed")
             ],
             auto_size=False,
-            selected='selected_files',
-            on_select=self.view_selected_row,
+            selected='object.selected_files',
             selection_mode='rows',
             editable=False
         )
@@ -183,11 +182,6 @@ class FileDisplayPane(TraitsDockPane):
                     _dictionary=data)
                 if table_row.shg and table_row.pl:
                     self.file_table.append(table_row)
-
-    def view_selected_row(self, selected_rows):
-        """Opens corresponding to the first item in
-        selected_rows"""
-        self.task.window.central_pane.selected_row = selected_rows[0]
 
     def remove_file(self, selected_rows):
         for selected_row in selected_rows:

--- a/pyfibre/gui/image_tab.py
+++ b/pyfibre/gui/image_tab.py
@@ -7,8 +7,8 @@ from chaco.default_colormaps import binary, reverse
 from enable.component_editor import ComponentEditor
 from traits.api import (
     HasTraits, Unicode, Instance, Function,
-    List, Int, Property, Str, Any, Dict)
-from traitsui.api import Item, View
+    List, Int, Property, Str, Any, Dict, Enum)
+from traitsui.api import Item, View, EnumEditor
 
 from pyfibre.model.multi_image.base_multi_image import BaseMultiImage
 from pyfibre.model.tools.figures import (
@@ -21,17 +21,21 @@ class ImageTab(HasTraits):
 
     label = Unicode()
 
-    selected_label = Str()
+    selected_label = Enum(values='image_labels')
 
     cmap = Function(reverse(binary))
 
     plot = Property(
         Instance(Plot),
-        depends_on='multi_image,plot_data,'
+        depends_on='plot_data,'
                    'selected_label')
 
     plot_data = Property(
         Any, depends_on='_image_dict'
+    )
+
+    image_labels = Property(
+        List(Str), depends_on='_image_dict'
     )
 
     _image_dict = Property(
@@ -42,18 +46,20 @@ class ImageTab(HasTraits):
             Item('plot',
                  editor=ComponentEditor(),
                  show_label=False),
+            Item('selected_label',
+                 editor=EnumEditor(
+                     name='object.image_labels'),
+                 style='simple'),
             resizable=True
         )
-
-    def _selected_label_default(self):
-        if self._image_dict:
-            return list(self._image_dict.keys())[0]
-        return ''
 
     def _get__image_dict(self):
         if self.multi_image is not None:
             return self.multi_image.image_dict
         return {}
+
+    def _get_image_labels(self):
+        return list(self._image_dict.keys())
 
     def _get_plot_data(self):
         return ArrayPlotData(**self._image_dict)
@@ -61,7 +67,6 @@ class ImageTab(HasTraits):
     def _get_plot(self):
 
         plot = Plot(self.plot_data)
-
         self._plot_image(plot)
 
         return plot

--- a/pyfibre/gui/options_pane.py
+++ b/pyfibre/gui/options_pane.py
@@ -34,6 +34,8 @@ class OptionsPane(TraitsDockPane):
 
     ow_network = Bool(False)
 
+    save_figures = Bool(False)
+
     save_database = Bool(False)
 
     database_filename = File('pyfibre_database')
@@ -64,6 +66,7 @@ class OptionsPane(TraitsDockPane):
             Item('ow_network', label="Overwrite Network?"),
             Item('ow_segment', label="Overwrite Segments?"),
             Item('ow_metric', label="Overwrite Metrics?"),
+            Item('save_figures', label="Save Figures?"),
             Item('save_database', label='Save Database?'),
             Item('database_filename',
                  label='Database file',

--- a/pyfibre/gui/pyfibre_main_task.py
+++ b/pyfibre/gui/pyfibre_main_task.py
@@ -47,6 +47,8 @@ class PyFibreMainTask(Task):
 
     file_display_pane = Instance(FileDisplayPane)
 
+    viewer_pane = Instance(ViewerPane)
+
     #: The Traits executor for the background jobs.
     traits_executor = Instance(TraitsExecutor, ())
 
@@ -102,6 +104,9 @@ class PyFibreMainTask(Task):
 
     def _file_display_pane_default(self):
         return FileDisplayPane()
+
+    def _viewer_pane_default(self):
+        return ViewerPane()
 
     def _menu_bar_default(self):
         """A menu bar with functions relevant to the Setup task.
@@ -166,6 +171,11 @@ class PyFibreMainTask(Task):
                 for future in self.current_futures
             ])
         return False
+
+    @on_trait_change('run_enabled')
+    def update_ui(self):
+        if self.run_enabled:
+            self.viewer_pane.update_viewer()
 
     @on_trait_change('current_futures:result_event')
     def _report_result(self, result):
@@ -238,7 +248,7 @@ class PyFibreMainTask(Task):
     def create_central_pane(self):
         """ Creates the central pane
         """
-        return ViewerPane()
+        return self.viewer_pane
 
     def create_dock_panes(self):
         """ Creates the dock panes

--- a/pyfibre/gui/pyfibre_main_task.py
+++ b/pyfibre/gui/pyfibre_main_task.py
@@ -176,7 +176,8 @@ class PyFibreMainTask(Task):
     def update_selected_row(self):
         """Opens corresponding to the first item in
         selected_rows"""
-        self.viewer_pane.selected_row = self.file_display_pane.selected_files[0]
+        self.viewer_pane.selected_row = (
+            self.file_display_pane.selected_files[0])
 
     @on_trait_change('run_enabled')
     def update_ui(self):

--- a/pyfibre/gui/pyfibre_main_task.py
+++ b/pyfibre/gui/pyfibre_main_task.py
@@ -172,14 +172,19 @@ class PyFibreMainTask(Task):
             ])
         return False
 
+    @on_trait_change('file_display_pane.selected_files')
+    def update_selected_row(self):
+        """Opens corresponding to the first item in
+        selected_rows"""
+        self.viewer_pane.selected_row = self.file_display_pane.selected_files[0]
+
     @on_trait_change('run_enabled')
     def update_ui(self):
         if self.run_enabled:
-            self.viewer_pane.update_viewer()
+            self.viewer_pane.update_image()
         self.create_databases()
-        if self.options_pane.save_database(
-                self.options_pane.database_filename):
-            self.save_database()
+        if self.options_pane.save_database:
+            self.save_database(self.options_pane.database_filename)
 
     @on_trait_change('current_futures:result_event')
     def _report_result(self, result):

--- a/pyfibre/gui/pyfibre_main_task.py
+++ b/pyfibre/gui/pyfibre_main_task.py
@@ -241,7 +241,7 @@ class PyFibreMainTask(Task):
                 ow_network=self.options_pane.ow_network,
                 ow_segment=self.options_pane.ow_segment,
                 ow_metric=self.options_pane.ow_metric,
-                save_figures=False)
+                save_figures=self.options_pane.save_figures)
             image_analyser = ImageAnalyser(
                 workflow=workflow
             )
@@ -265,34 +265,6 @@ class PyFibreMainTask(Task):
         """
         return [self.file_display_pane,
                 self.options_pane]
-
-    def create_figures(self):
-
-        file_table = self.file_display_pane.file_table
-        reader = SHGPLTransReader()
-        workflow = PyFibreWorkflow(
-            p_denoise=(self.options_pane.n_denoise,
-                       self.options_pane.m_denoise),
-            sigma=self.options_pane.sigma,
-            alpha=self.options_pane.alpha)
-        image_analyser = ImageAnalyser(
-            workflow=workflow
-        )
-
-        for row in file_table:
-
-            reader.assign_images(row._dictionary)
-            multi_image = reader.load_multi_image()
-
-            filenames = image_analyser.get_filenames(row.name)
-            (working_dir, data_dir, fig_dir,
-             filename, figname) = filenames
-
-            if not os.path.exists(fig_dir):
-                os.mkdir(fig_dir)
-
-            image_analyser.create_figures(
-                multi_image, filename, figname)
 
     def create_databases(self):
 

--- a/pyfibre/gui/pyfibre_main_task.py
+++ b/pyfibre/gui/pyfibre_main_task.py
@@ -176,6 +176,9 @@ class PyFibreMainTask(Task):
     def update_ui(self):
         if self.run_enabled:
             self.viewer_pane.update_viewer()
+        self.create_databases()
+        if self.options_pane.save_database:
+            self.save_database()
 
     @on_trait_change('current_futures:result_event')
     def _report_result(self, result):

--- a/pyfibre/gui/tests/test_image_tab.py
+++ b/pyfibre/gui/tests/test_image_tab.py
@@ -25,7 +25,7 @@ class TestImageTab(UnittestTools, TestCase):
 
         image_tab = ImageTab()
 
-        self.assertEqual('', image_tab.selected_label)
+        self.assertIsNone(image_tab.selected_label)
         self.assertDictEqual({}, image_tab._image_dict)
         self.assertDictEqual({}, image_tab.plot.data.arrays)
         self.assertListEqual([], image_tab.image_labels)
@@ -36,6 +36,13 @@ class TestImageTab(UnittestTools, TestCase):
             ['Test 1', 'Test 2'], self.image_tab.image_labels)
         with self.assertTraitChanges(self.image_tab, 'plot'):
             self.image_tab.selected_label = 'Test 2'
+
+    def test_multi_image_change(self):
+
+        image_tab = ImageTab()
+
+        with self.assertTraitChanges(image_tab, 'plot'):
+            image_tab.multi_image = self.multi_image
 
 
 class TestNetworkImageTab(TestCase):

--- a/pyfibre/gui/tests/test_image_tab.py
+++ b/pyfibre/gui/tests/test_image_tab.py
@@ -1,21 +1,25 @@
 from unittest import TestCase
 
+from traits.testing.unittest_tools import UnittestTools
+
 from pyfibre.gui.image_tab import ImageTab
 from pyfibre.tests.probe_classes import (
-    ProbeImageTab, ProbeNetworkImageTab, ProbeSegmentImageTab)
+    ProbeImageTab, ProbeNetworkImageTab, ProbeSegmentImageTab,
+    ProbeMultiImage)
 
 
-class TestImageTab(TestCase):
+class TestImageTab(UnittestTools, TestCase):
 
     def setUp(self):
 
         self.image_tab = ProbeImageTab()
+        self.multi_image = ProbeMultiImage()
 
     def test___init__(self):
 
         self.assertIsNotNone(self.image_tab.multi_image)
         self.assertIsNotNone(self.image_tab.plot)
-        self.assertEqual('Test', self.image_tab.selected_label)
+        self.assertEqual('Test 1', self.image_tab.selected_label)
 
     def test_empty_image_dict(self):
 
@@ -24,6 +28,14 @@ class TestImageTab(TestCase):
         self.assertEqual('', image_tab.selected_label)
         self.assertDictEqual({}, image_tab._image_dict)
         self.assertDictEqual({}, image_tab.plot.data.arrays)
+        self.assertListEqual([], image_tab.image_labels)
+
+    def test_image_labels(self):
+
+        self.assertListEqual(
+            ['Test 1', 'Test 2'], self.image_tab.image_labels)
+        with self.assertTraitChanges(self.image_tab, 'plot'):
+            self.image_tab.selected_label = 'Test 2'
 
 
 class TestNetworkImageTab(TestCase):

--- a/pyfibre/gui/tests/test_pyfibre_main_task.py
+++ b/pyfibre/gui/tests/test_pyfibre_main_task.py
@@ -2,6 +2,7 @@ import contextlib
 import threading
 from unittest import mock, TestCase
 
+from pyface.api import FileDialog, CANCEL
 from pyface.tasks.api import TaskWindow
 from traits_futures.toolkit_support import toolkit
 
@@ -13,11 +14,23 @@ from pyfibre.gui.viewer_pane import ViewerPane
 
 GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 
+FILE_DIALOG_PATH = "pyfibre.gui.pyfibre_main_task.FileDialog"
+FILE_OPEN_PATH = "pyfibre.io.database_io.save_database"
+
 
 def mock_run(*args, **kwargs):
     print('mock_run')
     print('done')
     return
+
+
+def mock_dialog(dialog_class, result, path=''):
+    def mock_dialog_call(*args, **kwargs):
+        dialog = mock.Mock(spec=dialog_class)
+        dialog.open = lambda: result
+        dialog.path = path
+        return dialog
+    return mock_dialog_call
 
 
 def get_probe_pyfibre_tasks():
@@ -102,3 +115,12 @@ class TestPyFibreMainTask(GuiTestAssistant, TestCase):
         self.assertEqual([], self.main_task.current_futures)
         self.assertTrue(self.main_task.run_enabled)
         self.assertFalse(self.main_task.stop_enabled)
+
+    def test_close_saving_dialog(self):
+        mock_open = mock.mock_open()
+        with mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, mock.patch(
+                FILE_OPEN_PATH, mock_open, create=True):
+            mock_file_dialog.side_effect = mock_dialog(FileDialog, CANCEL)
+
+            self.main_task.save_database_as()
+            mock_open.assert_not_called()

--- a/pyfibre/gui/tests/test_pyfibre_main_task.py
+++ b/pyfibre/gui/tests/test_pyfibre_main_task.py
@@ -7,6 +7,7 @@ from pyface.tasks.api import TaskWindow
 from traits_futures.toolkit_support import toolkit
 
 from pyfibre.tests.dummy_classes import DummyPyFibreGUI
+from pyfibre.tests.probe_classes import ProbeTableRow
 from pyfibre.gui.pyfibre_main_task import PyFibreMainTask
 from pyfibre.gui.options_pane import OptionsPane
 from pyfibre.gui.file_display_pane import FileDisplayPane
@@ -124,3 +125,12 @@ class TestPyFibreMainTask(GuiTestAssistant, TestCase):
 
             self.main_task.save_database_as()
             mock_open.assert_not_called()
+
+    def test_select_row(self):
+
+        table_row = ProbeTableRow()
+
+        self.main_task.file_display_pane.selected_files = [table_row]
+        self.assertEqual(
+            table_row,
+            self.main_task.viewer_pane.selected_row)

--- a/pyfibre/gui/tests/test_viewer_pane.py
+++ b/pyfibre/gui/tests/test_viewer_pane.py
@@ -3,15 +3,31 @@ from unittest import TestCase
 from pyfibre.gui.viewer_pane import (
     ViewerPane
 )
-from pyfibre.tests.probe_classes import ProbeMultiImage
+from pyfibre.tests.probe_classes import ProbeTableRow
 
 
 class TestViewerPane(TestCase):
 
     def setUp(self):
 
-        self.multi_image = ProbeMultiImage()
+        self.table_row = ProbeTableRow()
         self.viewer_pane = ViewerPane()
 
+    def test_selected_tab(self):
+
+        self.assertEqual(
+            self.viewer_pane.selected_tab, self.viewer_pane.multi_image_tab)
+
     def test_open_file(self):
-        pass
+
+        self.assertIsNone(self.viewer_pane.selected_image)
+        self.viewer_pane.selected_row = self.table_row
+
+        self.assertIsNotNone(self.viewer_pane.selected_image)
+        self.assertEqual(
+            self.viewer_pane.selected_image,
+            self.viewer_pane.selected_tab.multi_image)
+        self.assertListEqual(
+            ['SHG', 'PL', 'Trans'],
+            self.viewer_pane.selected_tab.image_labels
+        )

--- a/pyfibre/gui/tests/test_viewer_pane.py
+++ b/pyfibre/gui/tests/test_viewer_pane.py
@@ -13,11 +13,6 @@ class TestViewerPane(TestCase):
         self.table_row = ProbeTableRow()
         self.viewer_pane = ViewerPane()
 
-    def test_selected_tab(self):
-
-        self.assertEqual(
-            self.viewer_pane.selected_tab, self.viewer_pane.multi_image_tab)
-
     def test_open_file(self):
 
         self.assertIsNone(self.viewer_pane.selected_image)
@@ -30,4 +25,18 @@ class TestViewerPane(TestCase):
         self.assertListEqual(
             ['SHG', 'PL', 'Trans'],
             self.viewer_pane.selected_tab.image_labels
+        )
+
+    def test_selected_tab(self):
+
+        self.assertEqual(
+            self.viewer_pane.selected_tab,
+            self.viewer_pane.multi_image_tab)
+
+        self.viewer_pane.selected_row = self.table_row
+        self.viewer_pane.selected_tab.selected_label = 'PL'
+        self.viewer_pane.selected_tab = self.viewer_pane.image_tab_list[1]
+
+        self.assertEqual(
+            'PL', self.viewer_pane.selected_tab.selected_label
         )

--- a/pyfibre/model/tools/figures.py
+++ b/pyfibre/model/tools/figures.py
@@ -31,6 +31,8 @@ BASE_COLOURS = {
 def create_figure(image, filename, figsize=(10, 10),
                   ext='png', cmap='viridis'):
 
+    import matplotlib
+    matplotlib.use('Agg')
     import matplotlib.pyplot as plt
 
     plt.figure(figsize=figsize)

--- a/pyfibre/tests/probe_classes.py
+++ b/pyfibre/tests/probe_classes.py
@@ -10,9 +10,9 @@ from pyfibre.gui.image_tab import ImageTab, NetworkImageTab
 from pyfibre.gui.segment_image_tab import SegmentImageTab
 from pyfibre.gui.pyfibre_gui import PyFibreGUI
 from pyfibre.gui.pyfibre_main_task import PyFibreMainTask
+from pyfibre.gui.file_display_pane import TableRow
 from pyfibre.gui.pyfibre_plugin import PyFibrePlugin
 from pyfibre.model.multi_image.fixed_stack_image import FixedStackImage
-
 from pyfibre.model.objects.base_segment import BaseSegment
 from pyfibre.model.objects.fibre import Fibre
 from pyfibre.model.objects.fibre_network import FibreNetwork
@@ -106,12 +106,16 @@ class ProbeMultiImage(BaseMultiImage):
 
     def __init__(self, *args, **kwargs):
         image, _, _, _ = generate_image()
-        kwargs['image_stack'] = [image]
+        kwargs['image_stack'] = [image, 2 * image]
         super().__init__(*args, **kwargs)
         self.image_dict = {
-            'Test': self.image_stack[0]}
+            'Test 1': self.image_stack[0],
+            'Test 2': self.image_stack[1]}
 
     def preprocess_images(self):
+        pass
+
+    def verify_stack(cls, image_stack):
         pass
 
 
@@ -199,3 +203,11 @@ class ProbeFixedStackImage(FixedStackImage):
     _stack_len = 1
 
     _allowed_dim = [2]
+
+
+class ProbeTableRow(TableRow):
+
+    def __init__(self, *args, **kwargs):
+        kwargs['_dictionary'] = {
+            'SHG-PL-Trans': test_shg_pl_trans_image_path}
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
Work arounds to make sure that UI is updated the run is finished by reloading the selected image tab and creating databases. This is performed whenever the `PyFibreMainTask.run_enabled` attribute is changed to `True`. Ultimately a callback should be used whenever the run has finished, but this is not included in `traits_futures` at the moment.


Improved response time of image viewer by only updating image tabs that are being viewed.

Also closes #19 by introducing a `FileDialog` object that saves all loaded databases when selected and a `Save Figures` option in the Options Pane.