### PR TITLE
ENH: Allow multiple file / directory input for CLI

### DIFF
--- a/pyfibre/cli/app.py
+++ b/pyfibre/cli/app.py
@@ -71,8 +71,8 @@ from .pyfibre_cli import PyFibreCLI
     default='pyfibre'
 )
 @click.argument(
-    'file_path', type=click.Path(exists=True),
-    required=False, default='.'
+    'file_path', nargs=-1, type=click.Path(exists=True),
+    required=False
 )
 def pyfibre(file_path, key, sigma, alpha, log_name,
             database_name, debug, profile, ow_metric, ow_segment,

--- a/pyfibre/cli/pyfibre_cli.py
+++ b/pyfibre/cli/pyfibre_cli.py
@@ -14,7 +14,7 @@ from pyfibre.io.shg_pl_reader import (
     collate_image_dictionary,
     SHGPLTransReader
 )
-from pyfibre.io.utilities import parse_files, parse_file_path
+from pyfibre.io.utilities import parse_file_path
 from pyfibre.model.pyfibre_workflow import PyFibreWorkflow
 from pyfibre.model.image_analyser import ImageAnalyser
 from pyfibre.model.iterator import iterate_images

--- a/pyfibre/cli/pyfibre_cli.py
+++ b/pyfibre/cli/pyfibre_cli.py
@@ -48,11 +48,16 @@ class PyFibreCLI:
             'SHG-PL-Trans': SHGPLTransReader()
         }
 
-    def run(self, file_path):
+    def run(self, file_paths):
 
-        file_name, directory = parse_file_path(file_path)
-        input_files = parse_files(file_name, directory, self.key)
-        image_dictionary = collate_image_dictionary(input_files)
+        image_dictionary = {}
+
+        if isinstance(file_paths, str):
+            file_paths = [file_paths]
+
+        for file_path in file_paths:
+            input_files = parse_file_path(file_path, self.key)
+            image_dictionary.update(collate_image_dictionary(input_files))
 
         formatted_images = '\n'.join([
             f'\t{key}: {value}'

--- a/pyfibre/gui/file_display_pane.py
+++ b/pyfibre/gui/file_display_pane.py
@@ -14,7 +14,7 @@ from traitsui.api import (
 from pyfibre.io.shg_pl_reader import (
     collate_image_dictionary)
 from pyfibre.model.iterator import assign_images
-from pyfibre.io.utilities import parse_files, parse_file_path
+from pyfibre.io.utilities import parse_file_path
 
 
 def horizontal_centre(item_or_group):
@@ -171,9 +171,7 @@ class FileDisplayPane(TraitsDockPane):
 
     def add_files(self, file_path):
 
-        file_name, directory = parse_file_path(file_path)
-        input_files = parse_files(file_name, directory, self.key)
-
+        input_files = parse_file_path(file_path)
         image_dictionary = collate_image_dictionary(input_files)
 
         input_prefixes = [row.name for row in self.file_table]

--- a/pyfibre/io/tests/test_utilities.py
+++ b/pyfibre/io/tests/test_utilities.py
@@ -9,7 +9,7 @@ from pyfibre.tests.fixtures import test_shg_pl_trans_image_path
 from pyfibre.tests.probe_classes import generate_probe_graph
 
 from .. utilities import (
-    parse_files, parse_file_path, pop_under_recursive,
+    parse_file_path, pop_under_recursive,
     pop_dunder_recursive, numpy_to_python_recursive,
     python_to_numpy_recursive, replace_ext, save_json,
     load_json, serialize_networkx_graph, deserialize_networkx_graph,
@@ -37,30 +37,21 @@ class TestUtilities(TestCase):
         }
         self.graph = generate_probe_graph()
 
-    def test_parse_file_path(self):
-
-        file_name, directory = parse_file_path(
-            '/a/path/to/some/file-pl-shg.tif')
-
-        self.assertIsNone(file_name)
-        self.assertIsNone(directory)
-
-        file_name, directory = parse_file_path(self.file_name)
-        self.assertEqual(self.file_name, file_name)
-        self.assertIsNone(directory)
-
-        file_name, directory = parse_file_path(self.directory)
-        self.assertIsNone(file_name)
-        self.assertEqual(self.directory, directory)
-
     def test_parse_files(self):
 
-        input_files = parse_files(self.file_name, key=self.key)
-        self.assertEqual(input_files[0], self.file_name)
+        input_files = parse_file_path(
+            self.file_name, key=self.key)
+        self.assertEqual(1, len(input_files))
+        self.assertEqual(self.file_name, input_files[0])
 
-        input_files = parse_files(directory=self.directory,
-                                  key=self.key)
-        self.assertEqual(input_files[0], self.file_name)
+        input_files = parse_file_path(
+            self.directory, key=self.key)
+        self.assertEqual(2, len(input_files))
+        self.assertEqual(self.file_name, input_files[0])
+
+        input_files = parse_file_path(
+            self.directory, key='not-there')
+        self.assertListEqual([], input_files)
 
     def test_under_recursive(self):
 

--- a/pyfibre/io/utilities.py
+++ b/pyfibre/io/utilities.py
@@ -5,48 +5,25 @@ import numpy as np
 from networkx import node_link_graph, node_link_data
 
 
-def parse_files(name=None, directory=None, key=None):
-
+def parse_file_path(file_path, key=None):
+    """Parse input path in order to extract all files"""
     input_files = []
 
-    if key == '':
-        key = None
+    if os.path.isfile(file_path):
+        input_files.append(file_path)
 
-    if name is not None:
-        for file_name in name.split(','):
-            if file_name.find('/') == -1:
-                file_name = os.getcwd() + '/' + file_name
-            input_files.append(file_name)
-
-    if directory is not None:
-        for folder in directory.split(','):
-            for file_name in os.listdir(folder):
-                input_files += [folder + '/' + file_name]
+    elif os.path.isdir(file_path):
+        for file_name in os.listdir(file_path):
+            input_files.append(
+                os.path.join(file_path, file_name))
 
     if key is not None:
-        removed_files = []
-        for file_name in input_files:
-            if ((file_name.find(key) == -1) and
-                    (file_name not in removed_files)):
-                removed_files.append(file_name)
-
-        for file_name in removed_files:
-            input_files.remove(file_name)
+        input_files = [
+            input_file for input_file in input_files
+            if key in input_file
+        ]
 
     return input_files
-
-
-def parse_file_path(file_path):
-
-    file_name = None
-    directory = None
-
-    if os.path.isfile(file_path):
-        file_name = file_path
-    elif os.path.isdir(file_path):
-        directory = file_path
-
-    return file_name, directory
 
 
 def remove_under(dictionary):

--- a/pyfibre/model/iterator.py
+++ b/pyfibre/model/iterator.py
@@ -33,7 +33,7 @@ def iterate_images(dictionary, analyser, readers):
         try:
             multi_image = readers[image_type].load_multi_image(filenames)
         except (KeyError, ImportError):
-            logger.debug(f'Cannot process image data for {filenames}')
+            logger.info(f'Cannot process image data for {filenames}')
         else:
             logger.info(f"Processing image data for {filenames}")
 


### PR DESCRIPTION
The `PyFibre` CLI program can now take in multiple arguments for file paths and directories to include in its analysis.

Some minor refactoring also performed to file parser