### PR TITLE
FEAT: Include Network database and Fibre Angle SDI metric

### DIFF
--- a/pyfibre/cli/pyfibre_cli.py
+++ b/pyfibre/cli/pyfibre_cli.py
@@ -63,6 +63,7 @@ class PyFibreCLI:
 
         global_database = pd.DataFrame()
         fibre_database = pd.DataFrame()
+        network_database = pd.DataFrame()
         cell_database = pd.DataFrame()
 
         generator = iterate_images(
@@ -74,9 +75,11 @@ class PyFibreCLI:
                 databases[0], ignore_index=True)
 
             fibre_database = pd.concat([fibre_database, databases[1]])
-            cell_database = pd.concat([cell_database, databases[2]])
+            network_database = pd.concat([network_database, databases[2]])
+            cell_database = pd.concat([cell_database, databases[3]])
 
         if self.database_name:
             save_database(global_database, self.database_name)
             save_database(fibre_database, self.database_name, 'fibre')
+            save_database(network_database, self.database_name, 'network')
             save_database(cell_database, self.database_name, 'cell')

--- a/pyfibre/cli/tests/test_pyfibre_cli.py
+++ b/pyfibre/cli/tests/test_pyfibre_cli.py
@@ -20,6 +20,7 @@ def dummy_iterate_images(dictionary, analyser, reader):
         yield [
             pd.Series(dtype=object),
             pd.Series(dtype=object),
+            pd.Series(dtype=object),
             pd.Series(dtype=object)
         ]
 
@@ -65,5 +66,7 @@ class TestPyFibreCLI(TestCase):
                 os.path.exists(tmp_file.name + '.xls'))
             self.assertTrue(
                 os.path.exists(tmp_file.name + '_fibre.xls'))
+            self.assertTrue(
+                os.path.exists(tmp_file.name + '_network.xls'))
             self.assertTrue(
                 os.path.exists(tmp_file.name + '_cell.xls'))

--- a/pyfibre/gui/pyfibre_main_task.py
+++ b/pyfibre/gui/pyfibre_main_task.py
@@ -89,6 +89,7 @@ class PyFibreMainTask(Task):
 
         self.global_database = None
         self.fibre_database = None
+        self.network_database = None
         self.cell_database = None
 
     # ------------------
@@ -292,6 +293,7 @@ class PyFibreMainTask(Task):
 
         global_database = pd.DataFrame()
         fibre_database = pd.DataFrame()
+        network_database = pd.DataFrame()
         cell_database = pd.DataFrame()
 
         input_prefixes = [
@@ -308,12 +310,15 @@ class PyFibreMainTask(Task):
             try:
                 data_global = load_database(filename, 'global_metric')
                 data_fibre = load_database(filename, 'fibre_metric')
+                data_network = load_database(filename, 'network_metric')
                 data_cell = load_database(filename, 'cell_metric')
 
                 global_database = global_database.append(
                     data_global, ignore_index=True)
                 fibre_database = pd.concat(
                     [fibre_database, data_fibre], sort=True)
+                network_database = pd.concat(
+                    [network_database, data_network], sort=True)
                 cell_database = pd.concat(
                     [cell_database, data_cell], sort=True)
 
@@ -324,12 +329,14 @@ class PyFibreMainTask(Task):
 
         self.global_database = global_database
         self.fibre_database = fibre_database
+        self.network_database = network_database
         self.cell_database = cell_database
 
     def save_database(self, filename):
 
         save_database(self.global_database, filename)
         save_database(self.fibre_database, filename, 'fibre')
+        save_database(self.network_database, filename, 'network')
         save_database(self.cell_database, filename, 'cell')
 
     def save_database_as(self):

--- a/pyfibre/io/tests/test_utilities.py
+++ b/pyfibre/io/tests/test_utilities.py
@@ -56,11 +56,11 @@ class TestUtilities(TestCase):
     def test_parse_files(self):
 
         input_files = parse_files(self.file_name, key=self.key)
-        self.assertEqual(input_files[0], self.file_name)
+        self.assertIn(self.file_name, input_files)
 
         input_files = parse_files(directory=self.directory,
                                   key=self.key)
-        self.assertEqual(input_files[0], self.file_name)
+        self.assertIn(self.file_name, input_files)
 
     def test_under_recursive(self):
 

--- a/pyfibre/model/image_analyser.py
+++ b/pyfibre/model/image_analyser.py
@@ -207,7 +207,8 @@ class ImageAnalyser:
 
         save_database(global_dataframe, filename, 'global_metric')
         save_database(local_dataframes[0], filename, 'fibre_metric')
-        save_database(local_dataframes[1], filename, 'cell_metric')
+        save_database(local_dataframes[1], filename, 'network_metric')
+        save_database(local_dataframes[2], filename, 'cell_metric')
 
         end_time = time.time()
 
@@ -295,13 +296,12 @@ class ImageAnalyser:
 
         logger.info(f"TOTAL ANALYSIS TIME = {round(end - start, 3)} s")
 
-        databases = ()
-
         global_dataframe = load_database(filename, 'global_metric')
         fibre_dataframe = load_database(filename, 'fibre_metric')
-        databases += (global_dataframe, fibre_dataframe)
-
+        network_dataframe = load_database(filename, 'network_metric')
         cell_dataframe = load_database(filename, 'cell_metric')
-        databases += (cell_dataframe,)
+
+        databases = (global_dataframe, fibre_dataframe,
+                     network_dataframe, cell_dataframe)
 
         return databases

--- a/pyfibre/model/metric_analyser.py
+++ b/pyfibre/model/metric_analyser.py
@@ -7,11 +7,11 @@ import pandas as pd
 
 from pyfibre.model.tools.metrics import (
     SHAPE_METRICS, NEMATIC_METRICS, TEXTURE_METRICS,
-    FIBRE_METRICS, NETWORK_METRICS,
+    FIBRE_METRICS, NETWORK_METRICS, angle_analysis,
     fibre_network_metrics, segment_metrics
 )
 from pyfibre.model.multi_image.multi_images import SHGPLTransImage
-
+from pyfibre.utilities import flatten_list
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +64,7 @@ class MetricAnalyser:
         global_metrics = metric_averaging(
             local_metrics,
             shape_metrics + texture_metrics +
-            fibre_metrics + network_metrics +
-            ['Fibre Angle SDI']
+            fibre_metrics + network_metrics
         )
 
         return global_metrics
@@ -112,6 +111,12 @@ class MetricAnalyser:
             network_metrics, 'Fibre', 'SHG')
         global_network_metrics['No. Fibres'] = sum(
             network_metrics['No. Fibres'])
+        fibre_angles = flatten_list([
+            [fibre.angle for fibre in fibre_network.fibres]
+            for fibre_network in self.networks
+        ])
+        global_network_metrics['Fibre Angle SDI'] = angle_analysis(
+            fibre_angles)
         global_metrics = pd.concat(
             (global_segment_metrics,
              global_network_metrics), axis=0)

--- a/pyfibre/model/metric_analyser.py
+++ b/pyfibre/model/metric_analyser.py
@@ -64,7 +64,8 @@ class MetricAnalyser:
         global_metrics = metric_averaging(
             local_metrics,
             shape_metrics + texture_metrics +
-            fibre_metrics + network_metrics
+            fibre_metrics + network_metrics +
+            ['Fibre Angle SDI']
         )
 
         return global_metrics

--- a/pyfibre/model/metric_analyser.py
+++ b/pyfibre/model/metric_analyser.py
@@ -115,7 +115,7 @@ class MetricAnalyser:
             [fibre.angle for fibre in fibre_network.fibres]
             for fibre_network in self.networks
         ])
-        global_network_metrics['Fibre Angle SDI'] = angle_analysis(
+        global_network_metrics['Fibre Angle SDI'], _ = angle_analysis(
             fibre_angles)
         global_metrics = pd.concat(
             (global_segment_metrics,

--- a/pyfibre/model/objects/fibre_network.py
+++ b/pyfibre/model/objects/fibre_network.py
@@ -5,6 +5,7 @@ from pyfibre.io.utilities import (
     deserialize_networkx_graph,
     serialize_networkx_graph
 )
+from pyfibre.model.tools.analysis import angle_analysis
 from pyfibre.model.tools.metrics import (
     network_metrics, fibre_metrics, FIBRE_METRICS)
 from pyfibre.model.tools.fibre_assigner import FibreAssigner
@@ -83,6 +84,10 @@ class FibreNetwork(BaseGraph):
             self.graph, self.red_graph, len(self.fibres), 'Fibre')
 
         metrics = fibre_metrics(self.fibres)
+        database['Fibre Angle SDI'], _ = angle_analysis(
+            metrics['Fibre Angle'].to_numpy())
+
+        metrics = metrics.drop(['Fibre Angle'], axis=1)
         mean_metrics = metrics.mean()
 
         for metric in FIBRE_METRICS:

--- a/pyfibre/model/objects/tests/test_fibre.py
+++ b/pyfibre/model/objects/tests/test_fibre.py
@@ -73,6 +73,6 @@ class TestFibre(TestCase):
         self.assertIsInstance(database, pd.Series)
         self.assertEqual(3, len(database))
 
-        for metric in FIBRE_METRICS:
+        for metric in FIBRE_METRICS + ['Angle']:
             self.assertIn(
                 f'Fibre {metric}', database)

--- a/pyfibre/model/objects/tests/test_fibre_network.py
+++ b/pyfibre/model/objects/tests/test_fibre_network.py
@@ -89,7 +89,7 @@ class TestFibreNetwork(TestCase):
         self.network.fibres = self.fibres
 
         database = self.network.generate_database()
-        self.assertEqual(7, len(database))
+        self.assertEqual(8, len(database))
 
         self.assertIn('Fibre Angle SDI', database)
 

--- a/pyfibre/model/objects/tests/test_fibre_network.py
+++ b/pyfibre/model/objects/tests/test_fibre_network.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 from pyfibre.model.objects.fibre_network import (
     FibreNetwork
 )
-from pyfibre.model.tools.metrics import FIBRE_METRICS, NETWORK_METRICS
+from pyfibre.model.tools.metrics import (
+    FIBRE_METRICS, NETWORK_METRICS)
 from pyfibre.tests.probe_classes import ProbeFibreNetwork, ProbeFibre
 
 
@@ -89,6 +90,8 @@ class TestFibreNetwork(TestCase):
 
         database = self.network.generate_database()
         self.assertEqual(7, len(database))
+
+        self.assertIn('Fibre Angle SDI', database)
 
         for metric in FIBRE_METRICS:
             self.assertIn(f'Mean Fibre {metric}', database)

--- a/pyfibre/model/tests/test_metric_analyser.py
+++ b/pyfibre/model/tests/test_metric_analyser.py
@@ -37,10 +37,15 @@ class TestMetricAnalyser(TestCase):
         self.metric_analyser.image = self.shg_multi_image.shg_image
         self.metric_analyser.segments = self.fibre_segments
         self.metric_analyser.networks = self.fibre_networks
-        local_metrics, global_metrics = self.metric_analyser.analyse_shg()
+        (segment_metrics,
+         network_metrics,
+         global_metrics) = self.metric_analyser.analyse_shg()
 
-        self.assertEqual(18, len(local_metrics.columns))
-        self.assertEqual(18, len(global_metrics))
+        self.assertEqual((1, 11), segment_metrics.shape)
+        self.assertIn('File', segment_metrics)
+        self.assertEqual((1, 9), network_metrics.shape)
+        self.assertIn('File', network_metrics)
+        self.assertEqual((18,), global_metrics.shape)
 
     def test_analyse_pl(self):
 
@@ -48,8 +53,8 @@ class TestMetricAnalyser(TestCase):
         self.metric_analyser.segments = self.cell_segments
         local_metrics, global_metrics = self.metric_analyser.analyse_pl()
 
-        self.assertEqual(11, len(local_metrics.columns))
-        self.assertEqual(11, len(global_metrics))
+        self.assertEqual((1, 11), local_metrics.shape)
+        self.assertEqual((11,), global_metrics.shape)
 
     def test_generate_metrics(self):
 
@@ -62,9 +67,10 @@ class TestMetricAnalyser(TestCase):
             1.0
         )
 
-        self.assertEqual(2, len(local_dataframes))
-        self.assertEqual((1, 18), local_dataframes[0].shape)
-        self.assertIsNone(local_dataframes[1])
+        self.assertEqual(3, len(local_dataframes))
+        self.assertEqual((1, 11), local_dataframes[0].shape)
+        self.assertEqual((1, 9), local_dataframes[1].shape)
+        self.assertIsNone(local_dataframes[2])
         self.assertEqual((19,), global_dataframe.shape)
 
         global_dataframe, local_dataframes = generate_metrics(
@@ -76,7 +82,8 @@ class TestMetricAnalyser(TestCase):
             1.0
         )
 
-        self.assertEqual(2, len(local_dataframes))
-        self.assertEqual((1, 18), local_dataframes[0].shape)
-        self.assertEqual((1, 11), local_dataframes[1].shape)
+        self.assertEqual(3, len(local_dataframes))
+        self.assertEqual((1, 11), local_dataframes[0].shape)
+        self.assertEqual((1, 9), local_dataframes[1].shape)
+        self.assertEqual((1, 11), local_dataframes[2].shape)
         self.assertEqual((30,), global_dataframe.shape)

--- a/pyfibre/model/tools/analysis.py
+++ b/pyfibre/model/tools/analysis.py
@@ -136,6 +136,9 @@ def angle_analysis(angles, weights=None, n_bin=200):
         Angle and SDI values corresponding to each bin in histogram
     """
 
+    if not isinstance(angles, np.ndarray):
+        angles = np.array(angles)
+
     if weights is None:
         weights = np.ones(angles.shape)
 

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -114,6 +114,8 @@ def network_metrics(network, network_red, n_fibres, tag=''):
 
     database = pd.Series(dtype=object)
 
+    database['No. Fibres'] = n_fibres
+
     cross_links = np.array(
         [degree[1] for degree in network.degree],
         dtype=int)

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 NEMATIC_METRICS = ['Angle SDI', 'Anisotropy', 'Pixel Anisotropy']
 SHAPE_METRICS = ['Area', 'Eccentricity', 'Linearity', 'Coverage']
 TEXTURE_METRICS = ['Mean', 'STD', 'Entropy']
-FIBRE_METRICS = ['Waviness', 'Length', 'Angle']
+FIBRE_METRICS = ['Waviness', 'Length']
 NETWORK_METRICS = ['Degree', 'Eigenvalue', 'Connectivity',
                    'Cross-Link Density']
 

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -196,9 +196,8 @@ def fibre_network_metrics(fibre_networks):
         fibre_network_series = pd.concat(
             (fibre_network_series, metrics))
 
-        database = database.append(fibre_network_series, ignore_index=True)
-
-    # fibre_angle_sdi[i] = angle_analysis(fibre_ang, np.ones(fibre_ang.shape))
+        database = database.append(
+            fibre_network_series, ignore_index=True)
 
     return database
 

--- a/pyfibre/model/tools/tests/test_metrics.py
+++ b/pyfibre/model/tools/tests/test_metrics.py
@@ -85,7 +85,7 @@ class TestAnalysis(TestCase):
             'test')
 
         self.assertIsInstance(metrics, pd.Series)
-        self.assertEqual(4, len(metrics))
+        self.assertEqual(5, len(metrics))
 
         for metric in NETWORK_METRICS:
             self.assertIn(f'test Network {metric}', metrics)
@@ -98,7 +98,8 @@ class TestAnalysis(TestCase):
             [self.fibre_network])
 
         self.assertIsInstance(metrics, pd.DataFrame)
-        self.assertEqual((1, 7), metrics.shape)
+        self.assertEqual((1, 8), metrics.shape)
+        self.assertIn('No. Fibres', metrics)
 
         for metric in FIBRE_METRICS:
             self.assertIn(f'Mean Fibre {metric}', metrics)


### PR DESCRIPTION
This PR separates databases for fibre segments and fibre networks, as well as adding the `Fibre Angle SDI` metric to each `FibreNetwork` objects.

It also includes the global `Fibre Angle SDI` metric to use the full distribution of extracted fibre angles.