### PR TITLE
FIX: Bug in absolute file path in get_file_names function

### DIFF
--- a/pyfibre/io/tests/test_utilities.py
+++ b/pyfibre/io/tests/test_utilities.py
@@ -233,3 +233,19 @@ class TestUtilities(TestCase):
             '/path/to/some/file-pyfibre-analysis/data/file', filename)
         self.assertEqual(
             '/path/to/some/file-pyfibre-analysis/fig/file', figname)
+
+        test_path = 'local-file'
+
+        (working_dir, data_dir,
+         fig_dir, filename, figname) = get_file_names(test_path)
+
+        self.assertEqual(
+            'local-file-pyfibre-analysis', working_dir)
+        self.assertEqual(
+            'local-file-pyfibre-analysis/data', data_dir)
+        self.assertEqual(
+            'local-file-pyfibre-analysis/fig', fig_dir)
+        self.assertEqual(
+            'local-file-pyfibre-analysis/data/local-file', filename)
+        self.assertEqual(
+            'local-file-pyfibre-analysis/fig/local-file', figname)

--- a/pyfibre/io/tests/test_utilities.py
+++ b/pyfibre/io/tests/test_utilities.py
@@ -13,7 +13,7 @@ from .. utilities import (
     pop_dunder_recursive, numpy_to_python_recursive,
     python_to_numpy_recursive, replace_ext, save_json,
     load_json, serialize_networkx_graph, deserialize_networkx_graph,
-    check_file_name, check_string
+    check_file_name, check_string, get_file_names
 )
 
 
@@ -215,3 +215,21 @@ class TestUtilities(TestCase):
         self.assertEqual(
             "/dir/folder/test_file",
             check_file_name(string, 'SHG', 'pkl'))
+
+    def test_get_file_names(self):
+
+        test_path = '/path/to/some/file'
+
+        (working_dir, data_dir,
+         fig_dir, filename, figname) = get_file_names(test_path)
+
+        self.assertEqual(
+            '/path/to/some/file-pyfibre-analysis', working_dir)
+        self.assertEqual(
+            '/path/to/some/file-pyfibre-analysis/data', data_dir)
+        self.assertEqual(
+            '/path/to/some/file-pyfibre-analysis/fig', fig_dir)
+        self.assertEqual(
+            '/path/to/some/file-pyfibre-analysis/data/file', filename)
+        self.assertEqual(
+            '/path/to/some/file-pyfibre-analysis/fig/file', figname)

--- a/pyfibre/io/utilities.py
+++ b/pyfibre/io/utilities.py
@@ -194,15 +194,15 @@ def replace_ext(file_name, extension):
 def get_file_names(prefix):
 
     image_name = os.path.basename(prefix)
-    working_dir = (
-        f"{os.path.dirname(prefix)}/{image_name}"
-        "-pyfibre-analysis")
+    working_dir = os.path.join(
+        os.path.dirname(prefix),
+        f"{image_name}-pyfibre-analysis")
 
-    data_dir = working_dir + '/data/'
-    fig_dir = working_dir + '/fig/'
+    data_dir = os.path.join(working_dir, 'data')
+    fig_dir = os.path.join(working_dir, 'fig')
 
-    filename = data_dir + image_name
-    figname = fig_dir + image_name
+    filename = os.path.join(data_dir, image_name)
+    figname = os.path.join(fig_dir, image_name)
 
     return working_dir, data_dir, fig_dir, filename, figname
 


### PR DESCRIPTION
This PR fixes a bug in the `get_file_names` function, which returns an absolute file path as the working directory for any relative path argument passed in. Therefore using the argument `some-file` as the relative location will return `'/some-file-pyfibre-analysis'` as the absolute working directory, which is incorrect.

This is fixed by using `os.path.join`, which correctly identifies both relative and absolute file paths