### PR TITLE
FIX: FibreAssigner r coord

### DIFF
--- a/pyfibre/model/tools/fibre_assigner.py
+++ b/pyfibre/model/tools/fibre_assigner.py
@@ -75,8 +75,8 @@ class FibreAssigner:
 
         fibre = Fibre(nodes=[node, new_node])
 
-        fibre.graph.nodes[node]['xy'] = self._graph.nodes[node]['xy']
-        fibre.graph.nodes[new_node]['xy'] = self._graph.nodes[new_node]['xy']
+        fibre.graph.nodes[node]['xy'] = self.node_coord[node]
+        fibre.graph.nodes[new_node]['xy'] = self.node_coord[new_node]
         fibre.graph.add_edge(
             node, new_node, r=coord_r
         )
@@ -135,11 +135,11 @@ class FibreAssigner:
                 # Add node to end of growing Fibre
                 fibre.add_node(
                     new_node,
-                    xy=self._graph.nodes[new_node]['xy'].copy()
+                    xy=self.node_coord[new_node]
                 )
                 fibre.add_edge(
                     end_node, new_node,
-                    r=self._graph[new_node][end_node]['r'])
+                    r=self.r_coord[new_node][end_node])
 
             except (ValueError, IndexError):
                 fibre.growing = False

--- a/pyfibre/model/tools/fibre_assigner.py
+++ b/pyfibre/model/tools/fibre_assigner.py
@@ -24,7 +24,7 @@ class FibreAssigner:
 
         self._graph = None
         self.d_coord = None
-        self.r2_coord = None
+        self.r_coord = None
 
     @property
     def theta_thresh(self):
@@ -58,7 +58,8 @@ class FibreAssigner:
         # only once here once to ensure they are cached. This could be
         # replaced by using cached properties introduced in standard
         # library for Python 3.8
-        self.d_coord, self.r2_coord = distance_matrix(self.node_coord)
+        self.d_coord, r2_coord = distance_matrix(self.node_coord)
+        self.r_coord = np.sqrt(r2_coord)
 
     def _create_fibre(self, node):
         """Create a new Fibre instance beginning from node on
@@ -70,7 +71,7 @@ class FibreAssigner:
 
         # Obtain the most connected node as the first connection
         new_node = new_nodes[np.argsort(edge_list)][-1]
-        coord_r = self._graph[node][new_node]['r']
+        coord_r = self.r_coord[node][new_node]
 
         fibre = Fibre(nodes=[node, new_node])
 
@@ -102,13 +103,16 @@ class FibreAssigner:
             # Calculate vectors from end of fibre to new nodes
             new_coord_vec = self.d_coord[end_node][new_connect]
             new_coord_r = np.array([
-                self._graph[end_node][n]['r'] for n in new_connect
+                self.r_coord[end_node][n] for n in new_connect
             ])
 
             # Check no connected nodes have the same coordinates
             assert np.all(new_coord_r > 0), (
                 logger.exception(
-                    f"{end_node}, {new_connect}, {new_coord_vec},"
+                    f" {end_node}, {new_connect}, "
+                    f" {self.node_coord[end_node]}"
+                    f" {[self.node_coord[node] for node in new_connect]}"
+                    f" {new_coord_vec},"
                     f" {new_coord_r}, {fibre.node_list}"
                 )
             )

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -13,7 +13,7 @@ from pyfibre.model.tools.filters import form_structure_tensor
 
 logger = logging.getLogger(__name__)
 
-NEMATIC_METRICS = ['Angle SDI', 'Anisotropy', 'Pixel Anisotropy']
+NEMATIC_METRICS = ['Angle SDI', 'Anisotropy', 'Local Anisotropy']
 SHAPE_METRICS = ['Area', 'Eccentricity', 'Linearity', 'Coverage']
 TEXTURE_METRICS = ['Mean', 'STD', 'Entropy']
 FIBRE_METRICS = ['Waviness', 'Length']
@@ -40,7 +40,7 @@ def nematic_tensor_metrics(region, nematic_tensor, tag=''):
     database[f"{tag} Angle SDI"], _ = angle_analysis(
         segment_angle_map, segment_anis_map)
     database[f"{tag} Anisotropy"] = segment_anis[0]
-    database[f"{tag} Pixel Anisotropy"] = np.mean(segment_anis_map)
+    database[f"{tag} Local Anisotropy"] = np.mean(segment_anis_map)
 
     return database
 

--- a/pyfibre/model/tools/tests/test_fibre_assigner.py
+++ b/pyfibre/model/tools/tests/test_fibre_assigner.py
@@ -51,11 +51,12 @@ class TestFibreAssignment(PyFibreTestCase):
             self.fibre_assignment.d_coord[..., 1]
         )
         self.assertArrayAlmostEqual(
-            np.array([[0, 2, 8, 13],
-                      [2, 0, 2, 5],
-                      [8, 2, 0, 1],
-                      [13, 5, 1, 0]]),
-            self.fibre_assignment.r2_coord
+            np.sqrt(
+                np.array([[0, 2, 8, 13],
+                          [2, 0, 2, 5],
+                          [8, 2, 0, 1],
+                          [13, 5, 1, 0]])),
+            self.fibre_assignment.r_coord
         )
 
     def test_theta_thresh(self):


### PR DESCRIPTION
Minor fix to the `FibreAssigner` class - now includes `r_coord` attribute, which is used to assign distances between nodes rather than the `'r'` weight on each network. A bug was found in networks whereby multiple nodes could possess the same coordinates during processing.

Also changes the `Pixel Anisotropy` metric to `Local Anisotropy`