### PR TITLE
ENH: Use weighted mean for global averaging & rename nematic to structure metrics 

### DIFF
--- a/pyfibre/model/analysers/metric_analyser.py
+++ b/pyfibre/model/analysers/metric_analyser.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from pyfibre.model.tools.metrics import (
-    SHAPE_METRICS, NEMATIC_METRICS, TEXTURE_METRICS,
+    SHAPE_METRICS, STRUCTURE_METRICS, TEXTURE_METRICS,
     FIBRE_METRICS, NETWORK_METRICS, angle_analysis,
     fibre_network_metrics, segment_metrics
 )
@@ -52,7 +52,7 @@ class MetricAnalyser(ABC):
             for metric in SHAPE_METRICS]
         texture_metrics = [
             f'{segment_tag} Segment {image_tag} {metric}'
-            for metric in NEMATIC_METRICS + TEXTURE_METRICS]
+            for metric in STRUCTURE_METRICS + TEXTURE_METRICS]
         fibre_metrics = [
             f'Mean {segment_tag} {metric}' for metric in
             FIBRE_METRICS]

--- a/pyfibre/model/analysers/shg_analyser.py
+++ b/pyfibre/model/analysers/shg_analyser.py
@@ -233,19 +233,21 @@ class SHGAnalyser(BaseAnalyser):
         self._fibre_networks = fibre_network_assignment(self._network)
 
     @log_time(message='SEGMENTATION')
-    def segmentation_analysis(self, scale):
+    def segmentation_analysis(self, scale, segment_parameters):
         """Segment image into regions
 
         Parameters
         ----------
         scale: float
+        segment_parameters: Dict
 
         """
         logger.debug("Segmenting Fibre and Cell regions")
         self._fibre_segments, self._cell_segments = (
             self.multi_image.segmentation_algorithm(
                 self._fibre_networks,
-                scale=scale
+                scale=scale,
+                **segment_parameters
             )
         )
 
@@ -338,7 +340,8 @@ class SHGAnalyser(BaseAnalyser):
         # Load or create lists of FibreSegments
         if segment:
             self.segmentation_analysis(
-                scale=runner.scale)
+                scale=runner.scale,
+                segment_parameters=runner.segment_parameters)
             self._save_segments()
         else:
             self._load_segments()

--- a/pyfibre/model/tools/convertors.py
+++ b/pyfibre/model/tools/convertors.py
@@ -201,3 +201,14 @@ def binary_to_segments(binary, segment_klass,
     ]
 
     return segments
+
+
+def segments_to_binary(segments, shape):
+    """Transform list of BaseSegment instances into a binary array"""
+
+    stack = [
+        segment.to_array(shape=shape) for segment in segments
+    ]
+    binary = stack_to_binary(stack)
+
+    return binary

--- a/pyfibre/model/tools/convertors.py
+++ b/pyfibre/model/tools/convertors.py
@@ -110,7 +110,7 @@ def regions_to_binary(regions, shape):
 
 
 def binary_to_regions(binary, intensity_image=None,
-                      min_size=0, min_frac=0):
+                      min_size=0, min_frac=0.0):
     """Convert a binary mask image to a set of scikit-image
     segment objects"""
 

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -198,13 +198,15 @@ def fibre_network_metrics(fibre_networks):
     return database
 
 
-def segment_metrics(segments, image=None, image_tag=None, sigma=0.0001):
+def segment_metrics(segments, image, image_tag=None, sigma=0.0001):
     """Analysis of a list of `BaseSegment` objects
 
     Parameters
     ----------
     segments : list of `<class: BaseSegment>`
         List of cells to analyse
+    image: array-like
+        Full image to analyse
 
     Returns
     -------
@@ -214,11 +216,7 @@ def segment_metrics(segments, image=None, image_tag=None, sigma=0.0001):
     """
     database = pd.DataFrame()
 
-    if image is not None:
-        structure_tensor = form_structure_tensor(image, sigma)
-    else:
-        structure_tensor = form_structure_tensor(
-            segments[0].image, sigma)
+    structure_tensor = form_structure_tensor(image, sigma)
 
     for index, segment in enumerate(segments):
 

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -13,7 +13,7 @@ from pyfibre.model.tools.filters import form_structure_tensor
 
 logger = logging.getLogger(__name__)
 
-NEMATIC_METRICS = ['Angle SDI', 'Anisotropy', 'Local Anisotropy']
+STRUCTURE_METRICS = ['Angle SDI', 'Anisotropy', 'Local Anisotropy']
 SHAPE_METRICS = ['Area', 'Eccentricity', 'Linearity', 'Coverage']
 TEXTURE_METRICS = ['Mean', 'STD', 'Entropy']
 FIBRE_METRICS = ['Waviness', 'Length']
@@ -21,21 +21,17 @@ NETWORK_METRICS = ['Degree', 'Eigenvalue', 'Connectivity',
                    'Cross-Link Density']
 
 
-def nematic_tensor_metrics(region, nematic_tensor, tag=''):
+def structure_tensor_metrics(structure_tensor, tag=''):
     """Nematic tensor analysis for a scikit-image region"""
 
     database = pd.Series(dtype=object)
 
-    minr, minc, maxr, maxc = region.bbox
-    indices = np.mgrid[minr:maxr, minc:maxc]
-    segment_n_tensor = nematic_tensor[(indices[0], indices[1])]
-
     (segment_anis_map,
      segment_angle_map,
-     segment_angle_map) = tensor_analysis(segment_n_tensor)
+     segment_angle_map) = tensor_analysis(structure_tensor)
 
     segment_anis, _, _ = tensor_analysis(
-        np.mean(segment_n_tensor, axis=(0, 1)))
+        np.mean(structure_tensor, axis=(0, 1)))
 
     database[f"{tag} Angle SDI"], _ = angle_analysis(
         segment_angle_map, segment_anis_map)
@@ -219,9 +215,9 @@ def segment_metrics(segments, image=None, image_tag=None, sigma=0.0001):
     database = pd.DataFrame()
 
     if image is not None:
-        nematic_tensor = form_structure_tensor(image, sigma)
+        structure_tensor = form_structure_tensor(image, sigma)
     else:
-        nematic_tensor = form_structure_tensor(
+        structure_tensor = form_structure_tensor(
             segments[0].image, sigma)
 
     for index, segment in enumerate(segments):
@@ -234,9 +230,13 @@ def segment_metrics(segments, image=None, image_tag=None, sigma=0.0001):
         else:
             tensor_tag = ' '.join([segment._tag, 'Segment'])
 
-        nematic_metrics = nematic_tensor_metrics(
-            segment.region, nematic_tensor,
-            tensor_tag)
+        minr, minc, maxr, maxc = segment.region.bbox
+        indices = np.mgrid[minr:maxr, minc:maxc]
+        segment_tensor = structure_tensor[(indices[0], indices[1])]
+
+        nematic_metrics = structure_tensor_metrics(
+            segment_tensor, tensor_tag)
+
         segment_series = pd.concat((segment_series, nematic_metrics))
 
         database = database.append(segment_series, ignore_index=True)

--- a/pyfibre/model/tools/segmentation.py
+++ b/pyfibre/model/tools/segmentation.py
@@ -118,7 +118,11 @@ def create_fibre_filter(fibre_networks, shape,
     return fibre_filter
 
 
-def shg_segmentation(multi_image, fibre_networks, **kwargs):
+def shg_segmentation(
+        multi_image, fibre_networks,
+        min_fibre_size=100, min_cell_size=200,
+        min_fibre_frac=100, min_cell_frac=0.001,
+        **kwargs):
 
     fibre_filter = create_fibre_filter(
         fibre_networks, multi_image.shape)
@@ -129,18 +133,25 @@ def shg_segmentation(multi_image, fibre_networks, **kwargs):
     # Create a new set of segments for each fibre region
     fibre_segments = binary_to_segments(
         fibre_binary, FibreSegment,
-        multi_image.shg_image)
+        intensity_image=multi_image.shg_image,
+        min_size=min_fibre_size,
+        min_frac=min_fibre_frac)
 
     # Create a new set of segments for each cell region
     cell_segments = binary_to_segments(
         cell_binary, CellSegment,
         intensity_image=multi_image.shg_image,
-        min_size=200, min_frac=0.001)
+        min_size=min_cell_size,
+        min_frac=min_cell_frac)
 
     return fibre_segments, cell_segments
 
 
-def shg_pl_trans_segmentation(multi_image, fibre_networks, scale=1.0):
+def shg_pl_trans_segmentation(
+        multi_image, fibre_networks,
+        min_fibre_size=100, min_cell_size=200,
+        min_fibre_frac=100, min_cell_frac=0.001,
+        scale=1.0, **kwargs):
 
     # Create an image stack for the rgb_segmentation from SHG and PL
     # images
@@ -176,12 +187,15 @@ def shg_pl_trans_segmentation(multi_image, fibre_networks, scale=1.0):
     # Create a new set of segments for each fibre region
     fibre_segments = binary_to_segments(
         fibre_binary, FibreSegment,
-        intensity_image=multi_image.shg_image)
+        intensity_image=multi_image.shg_image,
+        min_size=min_fibre_size,
+        min_frac=min_fibre_frac)
 
     # Create a new set of segments for each cell region
     cell_segments = binary_to_segments(
         cell_binary, CellSegment,
-        intensity_image=multi_image.pl_image,
-        min_size=200, min_frac=0.01)
+        intensity_image=multi_image.shg_image,
+        min_size=min_cell_size,
+        min_frac=min_cell_frac)
 
     return fibre_segments, cell_segments

--- a/pyfibre/model/tools/tests/test_convertors.py
+++ b/pyfibre/model/tools/tests/test_convertors.py
@@ -3,11 +3,11 @@ import numpy as np
 from pyfibre.model.tools.convertors import (
     binary_to_stack, regions_to_binary, binary_to_regions,
     networks_to_binary, stack_to_binary, stack_to_regions,
-    regions_to_stack, binary_to_segments)
+    regions_to_stack, binary_to_segments, segments_to_binary)
 from pyfibre.tests.pyfibre_test_case import PyFibreTestCase
 from pyfibre.tests.probe_classes.objects import ProbeSegment
 from pyfibre.tests.probe_classes.utilities import (
-    generate_image, generate_probe_graph
+    generate_image, generate_probe_graph, generate_regions
 )
 
 
@@ -17,6 +17,10 @@ class TestConvertors(PyFibreTestCase):
         (self.image, self.labels,
          self.binary, self.stack) = generate_image()
         self.network = generate_probe_graph()
+        self.regions = generate_regions()
+        self.segments = [
+            ProbeSegment(region=region) for region in self.regions
+        ]
 
     def test_binary_to_stack(self):
 
@@ -55,8 +59,7 @@ class TestConvertors(PyFibreTestCase):
         self.assertEqual(3, regions[1].filled_area)
 
     def test_regions_to_binary(self):
-        regions = binary_to_regions(self.binary, self.image)
-        binary = regions_to_binary(regions, (10, 10))
+        binary = regions_to_binary(self.regions, (10, 10))
 
         self.assertEqual((10, 10), binary.shape)
         self.assertTrue((self.binary == binary).all())
@@ -101,13 +104,17 @@ class TestConvertors(PyFibreTestCase):
     def test_networks_to_segments(self):
         pass
 
-    def test_segments_to_stack(self):
-        segments = stack_to_regions(self.stack)
-        stack = regions_to_stack(segments, (10, 10))
+    def test_regions_to_stack(self):
+        stack = regions_to_stack(self.regions, (10, 10))
         self.assertArrayAlmostEqual(self.stack, stack)
 
-    def test_stack_to_segments(self):
-        segments = stack_to_regions(self.stack)
-        self.assertEqual(2, len(segments))
-        self.assertEqual(9, segments[0].filled_area)
-        self.assertEqual(3, segments[1].filled_area)
+    def test_stack_to_regions(self):
+        regions = stack_to_regions(self.stack)
+        self.assertEqual(2, len(regions))
+        self.assertEqual(9, regions[0].filled_area)
+        self.assertEqual(3, regions[1].filled_area)
+
+    def test_segments_to_binary(self):
+        binary = segments_to_binary(self.segments, (10, 10))
+        self.assertEqual((10, 10), binary.shape)
+        self.assertArrayAlmostEqual(self.binary, binary)

--- a/pyfibre/model/tools/tests/test_metrics.py
+++ b/pyfibre/model/tools/tests/test_metrics.py
@@ -5,9 +5,9 @@ import pandas as pd
 
 from pyfibre.model.tools.metrics import (
     SHAPE_METRICS, TEXTURE_METRICS, FIBRE_METRICS,
-    NETWORK_METRICS, NEMATIC_METRICS,
+    NETWORK_METRICS, STRUCTURE_METRICS,
     fibre_metrics, fibre_network_metrics,
-    nematic_tensor_metrics, region_shape_metrics,
+    structure_tensor_metrics, region_shape_metrics,
     region_texture_metrics, network_metrics)
 from pyfibre.tests.probe_classes.utilities import generate_regions
 from pyfibre.tests.probe_classes.objects import (
@@ -24,13 +24,13 @@ class TestAnalysis(TestCase):
 
     def test_nematic_tensor_metrics(self):
 
-        metrics = nematic_tensor_metrics(
-            self.regions[0], np.ones((10, 10, 2, 2)), 'test')
+        metrics = structure_tensor_metrics(
+            np.ones((10, 10, 2, 2)), 'test')
 
         self.assertIsInstance(metrics, pd.Series)
         self.assertEqual(3, len(metrics))
 
-        for metric in NEMATIC_METRICS:
+        for metric in STRUCTURE_METRICS:
             self.assertIn(f'test {metric}', metrics)
 
     def test_region_shape_metrics(self):

--- a/pyfibre/pyfibre_runner.py
+++ b/pyfibre/pyfibre_runner.py
@@ -28,6 +28,9 @@ class PyFibreRunner(HasStrictTraits):
     #: Parameters used for FIRE algorithm
     fire_parameters = Dict()
 
+    #: Parameters used for segmentation
+    segment_parameters = Dict()
+
     #: Toggles force overwrite of existing fibre network
     ow_network = Bool(False)
 
@@ -47,6 +50,14 @@ class PyFibreRunner(HasStrictTraits):
             'lmp_thresh': 0.15,
             'angle_thresh': 70,
             'r_thresh': 7
+        }
+
+    def _segment_parameters_default(self):
+        return {
+            'min_fibre_size': 100,
+            'min_fibre_frac': 0.1,
+            'min_cell_size': 200,
+            'min_cell_frac': 0.01,
         }
 
     def run_analysis(self, analyser):

--- a/pyfibre/tests/test_utilities.py
+++ b/pyfibre/tests/test_utilities.py
@@ -97,9 +97,13 @@ class TestUtilities(PyFibreTestCase):
 
         self.assertArrayAlmostEqual(answer, edit_array)
 
-        array_nan = np.array([2, 3, 1, np.nan])
+    def test_nanmean(self):
 
+        array_nan = np.array([2, 3, 1, np.nan])
         self.assertEqual(nanmean(array_nan), 2)
+
+        weights = np.array([3, 2, 5, 1])
+        self.assertAlmostEqual(nanmean(array_nan, weights), 1.7)
 
     def test_label_set(self):
 


### PR DESCRIPTION
The global averaging of segment metrics now uses a weighted mean, proportional to the relative sizes of each segment in the image. This is intended to reduce the impact of smaller segments, that may possess artefacts in their metrics due to resolution limits.

Additionally, we also allow the `PyFibreRunner` to set segmentation parameters, such as the minimum segment pixel area required for extraction by the software.

The 'nematic' tensor metrics are also renamed 'structure' tensor, since they are un-normalised