### PR TITLE
DEV: Dynamic plugin loading via stevedore

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -23,6 +23,7 @@ EDM_CORE_DEPS = [
     "sip>=4.18.1-1",
     "pyzmq==16.0.0-7",
     "swig==3.0.11-2",
+    "stevedore==1.29.0-7"
     "traits_futures==0.1.0-16"]
 
 EDM_DEV_DEPS = ["flake8==3.7.7-1",

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -23,7 +23,7 @@ EDM_CORE_DEPS = [
     "sip>=4.18.1-1",
     "pyzmq==16.0.0-7",
     "swig==3.0.11-2",
-    "stevedore==1.29.0-7"
+    "stevedore==1.29.0-7",
     "traits_futures==0.1.0-16"]
 
 EDM_DEV_DEPS = ["flake8==3.7.7-1",

--- a/pyfibre/cli/app.py
+++ b/pyfibre/cli/app.py
@@ -13,10 +13,9 @@ import click
 
 from pyfibre.shg_pl_trans.tests.fixtures import (
     test_shg_pl_trans_image_path)
-from pyfibre.shg_pl_trans.shg_pl_trans_plugin import SHGPLTransPlugin
 from pyfibre.core.core_pyfibre_plugin import CorePyFibrePlugin
+from pyfibre.utilities import logo, load_plugins
 
-from ..utilities import logo
 from ..version import __version__
 
 from .pyfibre_cli import PyFibreApplication
@@ -115,7 +114,8 @@ def run(file_path, key, sigma, alpha, log_name,
 
     logging.info(logo(__version__))
 
-    plugins = [CorePyFibrePlugin(), SHGPLTransPlugin()]
+    plugins = [CorePyFibrePlugin()]
+    plugins += load_plugins()
 
     pyfibre_app = PyFibreApplication(
         file_paths=file_path,

--- a/pyfibre/cli/tests/test_app.py
+++ b/pyfibre/cli/tests/test_app.py
@@ -18,11 +18,6 @@ def cd(dir):
 
 class TestCLIApp(TestCase):
 
-    def setUp(self):
-        self.name = 'file-shg.tif,/a/path/to/some/file-pl-shg.tif'
-        self.directory = ''
-        self.key = 'shg'
-
     def test_plain_invocation_mco(self):
         with cd(fixtures.directory):
             try:

--- a/pyfibre/core/base_pyfibre_plugin.py
+++ b/pyfibre/core/base_pyfibre_plugin.py
@@ -1,13 +1,22 @@
 from envisage.plugin import Plugin
-from traits.trait_types import List
+from traits.api import Property, List, Str, Int
 
-from pyfibre.ids import MULTI_IMAGE_FACTORIES
+from pyfibre.ids import MULTI_IMAGE_FACTORIES, plugin_id
 
 
 class BasePyFibrePlugin(Plugin):
     """Plugin that can be extended to provide additional multi
     image objects, such as IMultiImageFactory class"""
 
+    id = Property(Str)
+
+    #: Name of the plugin
+    name = Property(Str)
+
+    #: Version number of the plugin
+    version = Property(Int)
+
+    #: List of MultiImageFactories contributed by plugin
     multi_image_factories = List(
         contributes_to=MULTI_IMAGE_FACTORIES
     )
@@ -24,6 +33,26 @@ class BasePyFibrePlugin(Plugin):
             multi_image_factories=multi_image_factories,
             ** kwargs
         )
+
+    def _get_id(self):
+        """Getter that shadows public method for name"""
+        return plugin_id(self.name, self.version)
+
+    def _get_name(self):
+        """Getter that shadows public method for name"""
+        return self.get_name()
+
+    def _get_version(self):
+        """Getter that shadows public method for version"""
+        return self.get_version()
+
+    def get_name(self):
+        """Returns name of plugin"""
+        raise NotImplementedError
+
+    def get_version(self):
+        """Returns version number of plugin"""
+        raise NotImplementedError
 
     def get_multi_image_factories(self):
         """Returns a list of classes that provide an interface

--- a/pyfibre/core/tests/test_pyfibre_plugins.py
+++ b/pyfibre/core/tests/test_pyfibre_plugins.py
@@ -11,4 +11,7 @@ class TestPyFibrePlugins(TestCase):
 
     def test_init(self):
 
+        self.assertEqual('probe', self.plugin.name)
+        self.assertEqual(0, self.plugin.version)
+        self.assertEqual('pyfibre.plugin.probe.0', self.plugin.id)
         self.assertEqual(1, len(self.plugin.multi_image_factories))

--- a/pyfibre/gui/app.py
+++ b/pyfibre/gui/app.py
@@ -7,10 +7,9 @@ from traits.api import push_exception_handler
 
 from pyfibre.version import __version__
 from pyfibre.core.core_pyfibre_plugin import CorePyFibrePlugin
-from pyfibre.shg_pl_trans.shg_pl_trans_plugin import SHGPLTransPlugin
 from pyfibre.gui.pyfibre_gui import PyFibreGUI
 from pyfibre.gui.pyfibre_plugin import PyFibreGUIPlugin
-from pyfibre.utilities import logo
+from pyfibre.utilities import logo, load_plugins
 
 push_exception_handler(lambda *args: None,
                        reraise_exceptions=True)
@@ -55,7 +54,8 @@ def run(debug, profile):
     logger.info(logo(__version__))
 
     plugins = [CorePyFibrePlugin(), TasksPlugin(),
-               PyFibreGUIPlugin(), SHGPLTransPlugin()]
+               PyFibreGUIPlugin()]
+    plugins += load_plugins()
 
     pyfibre_gui = PyFibreGUI(plugins=plugins)
 

--- a/pyfibre/gui/file_display_pane.py
+++ b/pyfibre/gui/file_display_pane.py
@@ -177,7 +177,7 @@ class FileDisplayPane(TraitsDockPane):
                             file_names=file_names)
                         self.file_table.append(table_row)
                     except Exception:
-                        raise
+                        pass
 
     def remove_file(self, selected_rows):
         for selected_row in selected_rows:

--- a/pyfibre/ids.py
+++ b/pyfibre/ids.py
@@ -1,3 +1,19 @@
 TASKS = 'envisage.ui.tasks.tasks'
 
 MULTI_IMAGE_FACTORIES = 'pyfibre.core.multi_image_factories'
+
+
+def plugin_id(name, version):
+    """Creates an ID for the plugins.
+
+    Parameters
+    ----------
+    name: str
+        A string identifying the plugin.
+    version: int
+        A version number for the plugin.
+    """
+    if not isinstance(version, int) or version < 0:
+        raise ValueError("version must be a non negative integer")
+
+    return '.'.join(["pyfibre", "plugin", name, str(version)])

--- a/pyfibre/shg_pl_trans/shg_pl_trans_plugin.py
+++ b/pyfibre/shg_pl_trans/shg_pl_trans_plugin.py
@@ -7,5 +7,11 @@ class SHGPLTransPlugin(BasePyFibrePlugin):
     """Plugin that contributes a factory that can analyse
     an image format made of SHG and PL signals."""
 
+    def get_name(self):
+        return 'shg_pl_trans'
+
+    def get_version(self):
+        return 0
+
     def get_multi_image_factories(self):
         return [SHGPLTransFactory]

--- a/pyfibre/tests/probe_classes/plugins.py
+++ b/pyfibre/tests/probe_classes/plugins.py
@@ -7,6 +7,12 @@ from .factories import ProbeMultiImageFactory
 
 class ProbePyFibrePlugin(BasePyFibrePlugin):
 
+    def get_name(self):
+        return 'probe'
+
+    def get_version(self):
+        return 0
+
     def get_multi_image_factories(self):
         return [ProbeMultiImageFactory]
 

--- a/pyfibre/utilities.py
+++ b/pyfibre/utilities.py
@@ -8,8 +8,9 @@ Created on: 01/11/2015
 Last Modified: 12/04/2018
 """
 from functools import wraps
-import time
 import logging
+import time
+from stevedore import ExtensionManager
 
 import numpy as np
 
@@ -163,6 +164,19 @@ def matrix_split(matrix, nrows, ncols):
         grid += np.array_split(item, nrows, axis=-1)
 
     return grid
+
+
+def load_plugins():
+    """Load PyFibre plugins via Stevedore. """
+
+    mgr = ExtensionManager(
+        namespace='pyfibre.plugins',
+        invoke_on_load=True
+    )
+
+    plugins = [ext.obj for ext in mgr]
+
+    return plugins
 
 
 def log_time(message):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,11 @@ setup(
     packages=find_packages(),
     entry_points={
         'gui_scripts': ['PyFibre = pyfibre.cli.app:pyfibre',
-                        'PyFibre_GUI = pyfibre.gui.app:pyfibre']
+                        'PyFibre_GUI = pyfibre.gui.app:pyfibre'],
+        "pyfibre.plugins": [
+                    "shg_pl_trans = "
+                    "pyfibre.shg_pl_trans.shg_pl_trans_plugin"
+                    ":SHGPLTransPlugin"]
     },
     install_requires=REQUIREMENTS
 )


### PR DESCRIPTION
Loads `BasePyFibrePlugin` classes installed to local environment via `stevedore` extension manager

Developers now just need to install extension under `pyfibre.plugins` namespace, pointing to `BasePyFibrePlugin` subclass. This will automatically be detected and loaded in to `PyFibre` and `PyFibre_GUI` applications during start up.