### PR TITLE
FIX: Collate files in PyFibreRunner

### DIFF
--- a/pyfibre/cli/pyfibre_cli.py
+++ b/pyfibre/cli/pyfibre_cli.py
@@ -63,12 +63,14 @@ class PyFibreApplication(Application):
             tag: {} for tag, _ in self.supported_readers.items()
         }
 
+        input_files = []
         for file_path in self.file_paths:
-            input_files = parse_file_path(file_path, self.key)
-            for label, reader in self.supported_readers.items():
-                image_dictionary[label].update(
-                    reader.collate_files(input_files)
-                )
+            input_files += parse_file_path(file_path, self.key)
+
+        for label, reader in self.supported_readers.items():
+            image_dictionary[label].update(
+                reader.collate_files(input_files)
+            )
 
         for label, inner_dict in image_dictionary.items():
 

--- a/pyfibre/shg_pl_trans/tests/test_utils.py
+++ b/pyfibre/shg_pl_trans/tests/test_utils.py
@@ -64,7 +64,8 @@ class TestReader(TestCase):
         filtered_files = filter_input_files(input_files)
 
         self.assertListEqual(
-            ['/directory/prefix2-pl-shg-test.tif'], filtered_files)
+            ['/directory/prefix2-pl-shg-test.tif',
+             '/directory/prefix-shg-asterisco.tif'], filtered_files)
 
     def test_create_image_dictionary(self):
         input_files = ['/directory/prefix-pl-shg-test.tif',

--- a/pyfibre/shg_pl_trans/utils.py
+++ b/pyfibre/shg_pl_trans/utils.py
@@ -8,11 +8,9 @@ def filter_input_files(input_files):
     for filename in input_files:
         if not filename.endswith('.tif'):
             removed_files.append(filename)
-        elif filename.find('display') != -1:
+        elif 'display' in filename:
             removed_files.append(filename)
-        elif filename.find('virada') != -1:
-            removed_files.append(filename)
-        elif filename.find('asterisco') != -1:
+        elif 'virada' in filename != -1:
             removed_files.append(filename)
 
     for filename in removed_files:


### PR DESCRIPTION
Fixes a bug in `PyFibreRunner` file parser

Also allows file types with `asterisco` in the file name