### PR TITLE
ENH: Averaging of Segment Metrics only uses mask pixels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,27 @@
 Change Log
 ==========
 
+Release 2.0.1
+-------------
+
+Date:
+~~~~~
+19/07/2020
+
+Authors:
+~~~~~~~~
+Frank Longford
+
+Description:
+~~~~~~~~~~~~
+Minor patch fix for database generation
+
+Fixes
+^^^^^
+- Fix broken database generation in PyFibre GUI
+- Segment texture and structure tensor metrics are calculated using pixels in segment masks
+
+
 Release 2.0.0
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,10 @@ Once installed, simply create a "bootstrap" environment using the command line::
     edm install -e bootstrap --version 3.6 -y click setuptools
     edm shell -e bootstrap
 
-To begin with, either clone or download the latest release of PyFibre (currently 2.0.0) and change working
+To begin with, either clone or download the latest release of PyFibre (currently 2.0.1) and change working
 directory into the repository::
 
-    git clone --branch '2.0.0' --depth 1 https://github.com/franklongford/PyFibre.git
+    git clone --branch '2.0.1' --depth 1 https://github.com/franklongford/PyFibre.git
     cd PyFibre
 
 Then build the deployment ``pyfibre-py36`` environment using the following command::

--- a/pyfibre/model/core/base_segment.py
+++ b/pyfibre/model/core/base_segment.py
@@ -7,6 +7,7 @@ from skimage.measure import label, regionprops
 from pyfibre.model.tools.metrics import (
     region_shape_metrics, region_texture_metrics)
 from pyfibre.utilities import NotSupportedError
+from pyfibre.model.tools.utilities import bbox_indices
 
 from .base_pyfibre_object import BasePyFibreObject
 
@@ -55,12 +56,11 @@ class BaseSegment(BasePyFibreObject):
     def to_array(self, shape=None):
         """Return the object state in a form that can be
         serialised as a numpy array"""
-        minr, minc, maxr, maxc = self.region.bbox
+        indices = bbox_indices(self.region)
         if shape is None:
-            shape = (maxr, maxc)
-        indices = np.mgrid[minr:maxr, minc:maxc]
+            shape = self.region.bbox[2:]
         array = np.zeros(shape, dtype=np.int)
-        array[(indices[0], indices[1])] += self.region.image
+        array[indices] += self.region.image
 
         return array
 

--- a/pyfibre/model/tools/convertors.py
+++ b/pyfibre/model/tools/convertors.py
@@ -18,10 +18,10 @@ from skimage import measure
 from skimage.morphology import remove_small_holes
 from skimage.measure import regionprops
 
+from pyfibre.model.tools.figures import draw_network
 from pyfibre.utilities import label_set
 
-from .utilities import region_check
-from pyfibre.model.tools.figures import draw_network
+from .utilities import region_check, bbox_indices
 
 logger = logging.getLogger(__name__)
 
@@ -65,10 +65,10 @@ def regions_to_stack(regions, shape):
         (len(regions),) + shape, dtype=int)
 
     for index, region in enumerate(regions):
-        minr, minc, maxr, maxc = region.bbox
-        indices = np.mgrid[minr:maxr, minc:maxc]
         binary_image = np.zeros(shape, dtype=int)
-        binary_image[(indices[0], indices[1])] += region.image
+        indices = bbox_indices(region)
+
+        binary_image[indices] += region.image
         stack[index] += binary_image
 
     stack = np.where(stack, 1, 0)
@@ -101,9 +101,8 @@ def regions_to_binary(regions, shape):
     binary_image = np.zeros(shape, dtype=int)
 
     for region in regions:
-        minr, minc, maxr, maxc = region.bbox
-        indices = np.mgrid[minr:maxr, minc:maxc]
-        binary_image[(indices[0], indices[1])] += region.image
+        indices = bbox_indices(region)
+        binary_image[indices] += region.image
 
     binary_image = np.where(binary_image, 1, 0)
 

--- a/pyfibre/model/tools/figures.py
+++ b/pyfibre/model/tools/figures.py
@@ -16,7 +16,9 @@ from skimage.color import label2rgb, grey2rgb, rgb2hsv, hsv2rgb
 
 from pyfibre.model.tools.fibre_utilities import get_node_coord_array
 from pyfibre.model.tools.filters import form_structure_tensor
+from pyfibre.model.tools.utilities import bbox_indices
 from pyfibre.model.tools.analysis import tensor_analysis
+
 
 BASE_COLOURS = {
     'b': (0, 0, 1),
@@ -142,10 +144,9 @@ def create_region_image(image, regions):
     label = 1
 
     for region in regions:
-        minr, minc, maxr, maxc = region.bbox
-        indices = np.mgrid[minr:maxr, minc:maxc]
+        indices = bbox_indices(region)
 
-        label_image[(indices[0], indices[1])] += region.image * label
+        label_image[indices] += region.image * label
         label += 1
 
     image_label_overlay = label2rgb(

--- a/pyfibre/model/tools/tests/test_analysis.py
+++ b/pyfibre/model/tools/tests/test_analysis.py
@@ -55,6 +55,29 @@ class TestAnalysis(PyFibreTestCase):
         self.assertArrayAlmostEqual(np.array([45]), tot_angle)
         self.assertArrayAlmostEqual(np.array([0]), tot_energy)
 
+    def test_1d_tensor(self):
+        tensor_1d = np.array(
+            [[[0, 1], [1, 0]],
+             [[0, 0], [0, 1]]])
+
+        tot_anis, tot_angle, tot_energy = tensor_analysis(tensor_1d)
+        self.assertArrayAlmostEqual(np.array([0, 1]), tot_anis)
+        self.assertArrayAlmostEqual(np.array([45, 0]), tot_angle)
+        self.assertArrayAlmostEqual(np.array([0, 1]), tot_energy)
+
+    def test_2d_tensor(self):
+
+        tensor_2d = np.array(
+            [[[[0, 1], [1, 0]],
+              [[0, 0], [0, 1]]],
+             [[[1, 0], [0, -1]],
+              [[1, 0], [0, 0]]]])
+
+        tot_anis, tot_angle, tot_energy = tensor_analysis(tensor_2d)
+        self.assertArrayAlmostEqual(np.array([[0, 1], [0, 1]]), tot_anis)
+        self.assertArrayAlmostEqual(np.array([[45, 0], [90, 90]]), tot_angle)
+        self.assertArrayAlmostEqual(np.array([[0, 1], [2, 1]]), tot_energy)
+
     def test_angle_analysis(self):
         angles = np.array([45, 90, 100,
                            180, 45, 45,

--- a/pyfibre/model/tools/tests/test_metrics.py
+++ b/pyfibre/model/tools/tests/test_metrics.py
@@ -7,7 +7,7 @@ from pyfibre.model.tools.metrics import (
     SHAPE_METRICS, TEXTURE_METRICS, FIBRE_METRICS,
     NETWORK_METRICS, STRUCTURE_METRICS,
     fibre_metrics, fibre_network_metrics,
-    _segment_structure_tensor,
+    _region_sample,
     structure_tensor_metrics, region_shape_metrics,
     region_texture_metrics, network_metrics,
     segment_metrics)
@@ -27,6 +27,15 @@ class TestAnalysis(TestCase):
         self.segment = ProbeSegment()
         self.segments = [self.segment]
         self.image, _, _, _ = generate_image()
+
+    def test_region_sample(self):
+
+        structure_tensor = np.ones((10, 10, 2, 2))
+
+        region_tensor = _region_sample(
+            self.regions[0], structure_tensor)
+
+        self.assertEqual((9, 2, 2), region_tensor.shape)
 
     def test_structure_tensor_metrics(self):
         tensor_1d = np.array(
@@ -85,6 +94,10 @@ class TestAnalysis(TestCase):
         for metric in TEXTURE_METRICS:
             self.assertIn(f'test {metric}', metrics)
 
+        self.assertAlmostEqual(3.55555555, metrics['test Mean'])
+        self.assertAlmostEqual(1.83249138, metrics['test STD'])
+        self.assertAlmostEqual(1.35164411, metrics['test Entropy'])
+
         metrics = region_texture_metrics(
             self.regions[0], tag='test', glcm=True)
 
@@ -96,6 +109,10 @@ class TestAnalysis(TestCase):
 
         self.assertIsInstance(metrics, pd.Series)
         self.assertEqual(3, len(metrics))
+
+        self.assertAlmostEqual(1, metrics['test Mean'])
+        self.assertAlmostEqual(0, metrics['test STD'])
+        self.assertAlmostEqual(0, metrics['test Entropy'])
 
     def test_fibre_metrics(self):
 
@@ -137,16 +154,6 @@ class TestAnalysis(TestCase):
 
         for metric in NETWORK_METRICS:
             self.assertIn(f'Fibre Network {metric}', metrics)
-
-    def test_segment_structure_tensor(self):
-
-        segment = ProbeSegment()
-        structure_tensor = np.ones((10, 10, 2, 2))
-
-        segment_tensor = _segment_structure_tensor(
-            segment, structure_tensor)
-
-        self.assertEqual((9, 2, 2), segment_tensor.shape)
 
     def test_segment_metrics(self):
 

--- a/pyfibre/model/tools/tests/test_segment_utilities.py
+++ b/pyfibre/model/tools/tests/test_segment_utilities.py
@@ -3,11 +3,11 @@ from skimage.measure import regionprops
 
 from pyfibre.model.tools.utilities import (
     region_check, region_swap,
-    mean_binary
+    mean_binary, bbox_sample, bbox_indices
 )
 from pyfibre.model.tools.figures import draw_network
 from pyfibre.tests.probe_classes.utilities import (
-    generate_image, generate_probe_graph
+    generate_image, generate_probe_graph, generate_regions
 )
 from pyfibre.tests.pyfibre_test_case import PyFibreTestCase
 
@@ -18,6 +18,37 @@ class TestSegmentUtilities(PyFibreTestCase):
         (self.image, self.labels,
          self.binary, self.stack) = generate_image()
         self.network = generate_probe_graph()
+        self.regions = generate_regions()
+
+    def test_bbox_indices(self):
+        indices = bbox_indices(self.regions[0])
+        self.assertArrayAlmostEqual(
+            np.array([[0, 0, 0, 0],
+                      [1, 1, 1, 1],
+                      [2, 2, 2, 2],
+                      [3, 3, 3, 3],
+                      [4, 4, 4, 4],
+                      [5, 5, 5, 5]]),
+            indices[0]
+        )
+        self.assertArrayAlmostEqual(
+            np.array([[4, 5, 6, 7],
+                      [4, 5, 6, 7],
+                      [4, 5, 6, 7],
+                      [4, 5, 6, 7],
+                      [4, 5, 6, 7],
+                      [4, 5, 6, 7]]),
+            indices[1]
+        )
+
+    def test_bbox_sample(self):
+
+        global_image = np.ones((10, 10))
+
+        region_image = bbox_sample(
+            self.regions[0], global_image)
+
+        self.assertEqual((6, 4), region_image.shape)
 
     def test_segment_check(self):
         segment = regionprops(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '2.0.1.dev'
+VERSION = '2.0.1'
 
 #: Read description
 with open('README.rst', 'r') as readme:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '2.0.0.dev'
+VERSION = '2.0.1.dev'
 
 #: Read description
 with open('README.rst', 'r') as readme:


### PR DESCRIPTION
Closes #56 

Segments texture and structure tensor metrics are now calculated only using pixels that are within the region mask, not the bounding box.

Updates the version to 2.0.1.dev