### PR TITLE
FIX: Use total coverage of image for Global segment coverage metrics

### DIFF
--- a/pyfibre/addons/shg_pl_trans/metric_analysers.py
+++ b/pyfibre/addons/shg_pl_trans/metric_analysers.py
@@ -21,14 +21,21 @@ class SHGMetricAnalyser(MetricAnalyser):
             segment_metrics, 'Fibre', 'SHG', 'Fibre Segment Area')
         global_network_metrics = self._global_averaging(
             network_metrics, 'Fibre', 'SHG')
+
+        # Overwrite a couple of metrics to calculate the sum
+        # for the image, rather than the mean
         global_network_metrics['No. Fibres'] = sum(
             network_metrics['No. Fibres'])
+        global_segment_metrics['Fibre Segment Coverage'] = sum(
+            segment_metrics['Fibre Segment Area'] / self.image.size)
+
         fibre_angles = flatten_list([
             [fibre.angle for fibre in fibre_network.fibres]
             for fibre_network in self.networks
         ])
         global_network_metrics['Fibre Angle SDI'], _ = angle_analysis(
             fibre_angles)
+
         global_metrics = pd.concat(
             (global_segment_metrics,
              global_network_metrics), axis=0)
@@ -48,5 +55,7 @@ class PLMetricAnalyser(MetricAnalyser):
             segment_metrics, 'Cell', 'PL', 'Cell Segment Area')
 
         global_metrics['No. Cells'] = len(self.segments)
+        global_metrics['Cell Segment Coverage'] = sum(
+            segment_metrics['Cell Segment Area'] / self.image.size)
 
         return segment_metrics, global_metrics

--- a/pyfibre/addons/shg_pl_trans/tests/test_metric_analysers.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_metric_analysers.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from pyfibre.model.objects.segments import CellSegment, FibreSegment
-from pyfibre.tests.probe_classes.utilities import generate_regions, generate_image
+from pyfibre.tests.probe_classes.utilities import (
+    generate_regions, generate_image)
 from pyfibre.tests.probe_classes.objects import ProbeFibreNetwork
 from pyfibre.addons.shg_pl_trans.metric_analysers import (
     SHGMetricAnalyser, PLMetricAnalyser)

--- a/pyfibre/addons/shg_pl_trans/tests/test_metric_analysers.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_metric_analysers.py
@@ -1,22 +1,16 @@
 from unittest import TestCase
 
 from pyfibre.model.objects.segments import CellSegment, FibreSegment
-from pyfibre.tests.probe_classes.utilities import generate_regions
+from pyfibre.tests.probe_classes.utilities import generate_regions, generate_image
 from pyfibre.tests.probe_classes.objects import ProbeFibreNetwork
 from pyfibre.addons.shg_pl_trans.metric_analysers import (
     SHGMetricAnalyser, PLMetricAnalyser)
-
-from .probe_classes import (
-    ProbeSHGImage,
-    ProbeSHGPLTransImage)
 
 
 class TestMetricAnalyser(TestCase):
 
     def setUp(self):
 
-        self.shg_multi_image = ProbeSHGImage()
-        self.shg_pl_multi_image = ProbeSHGPLTransImage()
         self.shg_metric_analyser = SHGMetricAnalyser(
             filename='test', sigma=0.5
         )
@@ -25,34 +19,46 @@ class TestMetricAnalyser(TestCase):
         )
         self.fibre_network = ProbeFibreNetwork()
 
+        self.image, _, _, _ = generate_image()
         regions = generate_regions()
-        self.fibre_segment = FibreSegment(region=regions[0])
-        self.cell_segment = CellSegment(region=regions[1])
+        self.fibre_segments = [
+            FibreSegment(region=region) for region in regions]
+        self.cell_segments = [CellSegment(region=regions[1])]
 
         self.fibre_networks = [self.fibre_network]
-        self.fibre_segments = [self.fibre_segment]
-        self.cell_segments = [self.cell_segment]
+        self.fibre_segment = self.fibre_segments[0]
+        self.cell_segment = self.cell_segments[0]
 
     def test_analyse_shg(self):
 
-        self.shg_metric_analyser.image = self.shg_multi_image.shg_image
+        self.shg_metric_analyser.image = self.image
         self.shg_metric_analyser.segments = self.fibre_segments
         self.shg_metric_analyser.networks = self.fibre_networks
         (segment_metrics,
          network_metrics,
          global_metrics) = self.shg_metric_analyser.analyse()
 
-        self.assertEqual((1, 11), segment_metrics.shape)
+        self.assertEqual((2, 11), segment_metrics.shape)
         self.assertIn('File', segment_metrics)
         self.assertEqual((1, 9), network_metrics.shape)
         self.assertIn('File', network_metrics)
         self.assertEqual((18,), global_metrics.shape)
 
+        self.assertEqual(
+            1, global_metrics['No. Fibres'])
+        self.assertEqual(
+            12/100, global_metrics['Fibre Segment Coverage'])
+
     def test_analyse_pl(self):
 
-        self.pl_metric_analyser.image = self.shg_pl_multi_image.pl_image
+        self.pl_metric_analyser.image = self.image
         self.pl_metric_analyser.segments = self.cell_segments
         local_metrics, global_metrics = self.pl_metric_analyser.analyse()
 
         self.assertEqual((1, 11), local_metrics.shape)
         self.assertEqual((11,), global_metrics.shape)
+
+        self.assertEqual(
+            1, global_metrics['No. Cells'])
+        self.assertEqual(
+            3 / 100, global_metrics['Cell Segment Coverage'])


### PR DESCRIPTION
Rather than using average coverage of the segment bounding boxes, when calculating the global coverage metrics calculate the total coverage of the image that contains the segments

Closes #17 