### PR TITLE
FIX: Remove normalisation from image preprocessing

### DIFF
--- a/pyfibre/addons/shg_pl_trans/shg_reader.py
+++ b/pyfibre/addons/shg_pl_trans/shg_reader.py
@@ -150,13 +150,6 @@ class SHGReader(BaseMultiImageReader):
         if minor_axis is not None:
             image = np.mean(image, axis=minor_axis)
 
-        # If 2D array, simply normalise and return as float
-        if image.ndim == 2:
-            image = image / image.max()
-        elif image.ndim > 2:
-            for index, channel in enumerate(image):
-                image[index] = channel / channel.max()
-
         return img_as_float(image)
 
     def load_image(self, filename):

--- a/pyfibre/addons/shg_pl_trans/tests/test_shg_reader.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_shg_reader.py
@@ -89,11 +89,14 @@ class TestSHGReader(PyFibreTestCase):
 
     def test__format_image(self):
 
+        expected_2D_array = np.ones((10, 10)) * 2
+        expected_3D_array = np.ones((10, 10, 3)) * 2
+
         image = self.reader._format_image(
             np.ones((10, 10)) * 2
         )
         self.assertArrayAlmostEqual(
-            np.ones((10, 10)),
+            expected_2D_array,
             image
         )
         self.assertEqual(np.float, image.dtype)
@@ -102,7 +105,7 @@ class TestSHGReader(PyFibreTestCase):
             np.ones((10, 10, 3)) * 2
         )
         self.assertArrayAlmostEqual(
-            np.ones((10, 10, 3)),
+            expected_3D_array,
             image
         )
 
@@ -110,7 +113,7 @@ class TestSHGReader(PyFibreTestCase):
             np.ones((10, 10, 3)) * 2, 2
         )
         self.assertArrayAlmostEqual(
-            np.ones((10, 10)),
+            expected_2D_array,
             image
         )
 
@@ -120,8 +123,11 @@ class TestSHGReader(PyFibreTestCase):
         image = self.reader._format_image(
             test_image, 1
         )
+        expected_array = np.ones((3, 10, 10))
+        expected_array[0] *= 2
+        expected_array[2] *= 3
         self.assertArrayAlmostEqual(
-            np.ones((3, 10, 10)),
+            expected_array,
             image
         )
 

--- a/pyfibre/addons/shg_pl_trans/tools/segmentation.py
+++ b/pyfibre/addons/shg_pl_trans/tools/segmentation.py
@@ -60,7 +60,7 @@ def shg_segmentation(
 def shg_pl_trans_segmentation(
         multi_image, fibre_networks,
         min_fibre_size=100, min_cell_size=200,
-        min_fibre_frac=100, min_cell_frac=0.001,
+        min_fibre_frac=100, min_cell_frac=0.1,
         scale=1.0, **kwargs):
 
     # Create an image stack for the rgb_segmentation from SHG and PL
@@ -109,7 +109,7 @@ def shg_pl_trans_segmentation(
     # Create a new set of segments for each cell region
     cell_segments = binary_to_segments(
         cell_binary, CellSegment,
-        intensity_image=multi_image.shg_image,
+        intensity_image=multi_image.pl_image,
         min_size=min_cell_size,
         min_frac=min_cell_frac)
 

--- a/pyfibre/gui/image_tab.py
+++ b/pyfibre/gui/image_tab.py
@@ -101,7 +101,7 @@ class ImageTab(BaseDisplayTab):
 class TensorImageTab(ImageTab):
 
     def _tensor_image(self, image):
-        return create_tensor_image(image) * 255.999
+        return create_tensor_image(image)
 
     def _get_plot_data(self):
         """Convert each image into a tensor image"""
@@ -126,7 +126,7 @@ class NetworkImageTab(ImageTab):
         return create_network_image(
             image,
             self.networks,
-            c_mode=self.c_mode) * 255.999
+            c_mode=self.c_mode)
 
     def _get_plot_data(self):
         """Convert each image into a network image"""

--- a/pyfibre/gui/segment_image_tab.py
+++ b/pyfibre/gui/segment_image_tab.py
@@ -25,7 +25,7 @@ class SegmentImageTab(ImageTab):
     def _region_image(self, image):
         return create_region_image(
             image,
-            self.regions) * 255.999
+            self.regions)
 
     def _get_plot_data(self):
         """Convert each image into a segment image"""

--- a/pyfibre/model/tools/figures.py
+++ b/pyfibre/model/tools/figures.py
@@ -123,7 +123,7 @@ def create_tensor_image(image, min_N=50):
 
     # Form structure tensor image
     rgb_image = create_hsb_image(
-        image, hue, saturation, brightness)
+        image, hue, saturation, brightness) * 255.999
 
     return rgb_image
 
@@ -153,11 +153,13 @@ def create_region_image(image, regions):
         label_image, image=image, bg_label=0,
         image_alpha=0.99, alpha=0.25, bg_color=(0, 0, 0))
 
-    return image_label_overlay
+    return image_label_overlay * 255.9999
 
 
 def create_network_image(image, networks, c_mode=0):
     """Create image with overlayed fibre networks"""
+
+    image *= 255.9999 / image.max()
 
     colours = list(BASE_COLOURS.keys())
 

--- a/pyfibre/model/tools/preprocessing.py
+++ b/pyfibre/model/tools/preprocessing.py
@@ -38,7 +38,10 @@ def clip_intensities(image, p_intensity=(1, 98)):
         f"intensity percentages {p_intensity}")
     low, high = np.percentile(image, p_intensity)
     image = rescale_intensity(
-        image, in_range=(low, high), out_range=(0.0, 1.0))
+        image,
+        in_range=(low, high),
+        out_range=(low, high)
+    )
 
     return image
 

--- a/pyfibre/model/tools/tests/test_figures.py
+++ b/pyfibre/model/tools/tests/test_figures.py
@@ -65,13 +65,13 @@ class TestFigures(PyFibreTestCase):
         self.assertEqual(
             (10, 10, 3), segment_image.shape)
         self.assertTrue(
-            np.allclose(segment_image[..., 0][indices], 0.0075)
+            np.allclose(segment_image[..., 0][indices], 1.92)
         )
         self.assertTrue(
-            np.allclose(segment_image[..., 1][indices], 0.0075)
+            np.allclose(segment_image[..., 1][indices], 1.92)
         )
         self.assertTrue(
-            np.allclose(segment_image[..., 2][indices], 0.0075)
+            np.allclose(segment_image[..., 2][indices], 1.92)
         )
 
     def test_create_network_image(self):

--- a/pyfibre/model/tools/tests/test_preprocessing.py
+++ b/pyfibre/model/tools/tests/test_preprocessing.py
@@ -16,13 +16,13 @@ class TestPreprocessing(TestCase):
         clipped_image = clip_intensities(self.image,
                                          p_intensity=(1, 95))
 
-        self.assertEqual(clipped_image[2, 2], 1)
-        self.assertEqual(clipped_image[1, 1], 1)
+        self.assertAlmostEqual(clipped_image[2, 2], 4.2)
+        self.assertAlmostEqual(clipped_image[1, 1], 4.2)
 
         clipped_image = clip_intensities(self.image,
                                          p_intensity=(1, 96))
-        self.assertEqual(clipped_image[2, 2], 1)
-        self.assertAlmostEqual(clipped_image[1, 1], 0.9523809, 6)
+        self.assertAlmostEqual(clipped_image[2, 2], 5.2)
+        self.assertAlmostEqual(clipped_image[1, 1], 5.0, 6)
 
     def test_nl_means(self):
 


### PR DESCRIPTION
Remove normalisation process from `clip_intensities` and `SHGReader._format_image ` so that image metrics always use values that are scaled to their raw image intensity values.

This is important when comparing metrics that are sensitive to the absolute image pixel values, such as "Mean Intensity"