### PR TITLE
Fix saved image brightness

### DIFF
--- a/pyfibre/gui/image_tab.py
+++ b/pyfibre/gui/image_tab.py
@@ -14,6 +14,7 @@ from pyfibre.core.base_multi_image import BaseMultiImage
 from pyfibre.core.base_multi_image_viewer import BaseDisplayTab
 from pyfibre.model.tools.figures import (
     create_tensor_image, create_network_image)
+from pyfibre.utilities import IMAGE_MAX
 
 
 class ImageTab(BaseDisplayTab):
@@ -114,7 +115,7 @@ class ImageTab(BaseDisplayTab):
 class TensorImageTab(ImageTab):
 
     def _tensor_image(self, image):
-        return create_tensor_image(image)
+        return create_tensor_image(image) * IMAGE_MAX
 
     def _update_image_data(self):
         """Convert each image into a tensor image"""
@@ -137,7 +138,7 @@ class NetworkImageTab(ImageTab):
         return create_network_image(
             image,
             self.networks,
-            c_mode=self.c_mode)
+            c_mode=self.c_mode) * IMAGE_MAX
 
     def _update_image_data(self):
         """Convert each image into a network image"""

--- a/pyfibre/gui/segment_image_tab.py
+++ b/pyfibre/gui/segment_image_tab.py
@@ -4,6 +4,7 @@ from traits.api import List
 from pyfibre.gui.metric_tab import ImageMetricTab
 from pyfibre.model.core.base_segment import BaseSegment
 from pyfibre.model.tools.figures import create_region_image
+from pyfibre.utilities import IMAGE_MAX
 
 
 class SegmentImageTab(ImageMetricTab):
@@ -13,7 +14,7 @@ class SegmentImageTab(ImageMetricTab):
     def _region_image(self, image):
         return create_region_image(
             image,
-            [segment.region for segment in self.segments])
+            [segment.region for segment in self.segments]) * IMAGE_MAX
 
     def _update_image_data(self):
         """Convert each image into a segment image"""

--- a/pyfibre/model/tools/base_kmeans_filter.py
+++ b/pyfibre/model/tools/base_kmeans_filter.py
@@ -21,6 +21,8 @@ from skimage.exposure import equalize_hist
 
 from sklearn.cluster import MiniBatchKMeans
 
+from pyfibre.utilities import IMAGE_MAX
+
 from .preprocessing import clip_intensities
 
 logger = logging.getLogger(__name__)
@@ -60,7 +62,7 @@ class BaseKmeansFilter(ABC):
 
         # Mimic contrast stretching decorrstrech routine in MatLab
         for i in range(image_channels):
-            image_scaled[:, :, i] = 255 * clip_intensities(
+            image_scaled[:, :, i] = IMAGE_MAX * clip_intensities(
                 image[:, :, i], p_intensity=self.p_intensity)
 
         # Pad each channel, equalise and smooth to remove
@@ -70,7 +72,7 @@ class BaseKmeansFilter(ABC):
                 image_scaled[:, :, i],
                 [pad_size, pad_size],
                 'symmetric')
-            equalised = 255 * equalize_hist(padded)
+            equalised = IMAGE_MAX * equalize_hist(padded)
 
             # Double median filter
             for j in range(2):

--- a/pyfibre/model/tools/figures.py
+++ b/pyfibre/model/tools/figures.py
@@ -13,6 +13,7 @@ import numpy as np
 from skimage import draw
 from skimage.transform import rotate
 from skimage.color import label2rgb, grey2rgb, rgb2hsv, hsv2rgb
+from skimage.exposure import rescale_intensity
 
 from pyfibre.model.tools.fibre_utilities import get_node_coord_array
 from pyfibre.model.tools.filters import form_structure_tensor
@@ -28,6 +29,10 @@ BASE_COLOURS = {
     'm': (0.75, 0, 0.75),
     'y': (0.75, 0.75, 0),
     'k': (0, 0, 0)}
+
+
+def _normalise_image(image):
+    return rescale_intensity(image, out_range=(0, 1))
 
 
 def create_figure(image, filename, figsize=(10, 10),
@@ -123,7 +128,7 @@ def create_tensor_image(image, min_N=50):
 
     # Form structure tensor image
     rgb_image = create_hsb_image(
-        image, hue, saturation, brightness) * 255.999
+        image, hue, saturation, brightness)
 
     return rgb_image
 
@@ -139,7 +144,7 @@ def create_region_image(image, regions):
         List of segmented regions
     """
 
-    image /= image.max()
+    image = _normalise_image(image)
     label_image = np.zeros(image.shape, dtype=int)
     label = 1
 
@@ -153,13 +158,13 @@ def create_region_image(image, regions):
         label_image, image=image, bg_label=0,
         image_alpha=0.99, alpha=0.25, bg_color=(0, 0, 0))
 
-    return image_label_overlay * 255.9999
+    return image_label_overlay
 
 
 def create_network_image(image, networks, c_mode=0):
     """Create image with overlayed fibre networks"""
 
-    image *= 255.9999 / image.max()
+    image = _normalise_image(image)
 
     colours = list(BASE_COLOURS.keys())
 
@@ -187,7 +192,7 @@ def create_network_image(image, networks, c_mode=0):
                     node_coord[n][0], node_coord[n][1])
 
                 for i, c in enumerate(colour):
-                    rgb_image[rr, cc, i] = c * val * 255.9999
+                    rgb_image[rr, cc, i] = c * val
 
     return rgb_image
 

--- a/pyfibre/model/tools/metrics.py
+++ b/pyfibre/model/tools/metrics.py
@@ -11,6 +11,7 @@ from pyfibre.model.tools.analysis import (
 from pyfibre.model.tools.feature import greycoprops_edit
 from pyfibre.model.tools.filters import form_structure_tensor
 from pyfibre.model.tools.utilities import bbox_sample
+from pyfibre.utilities import IMAGE_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ def region_texture_metrics(region, image=None, tag='', glcm=False):
     if glcm:
 
         glcm = greycomatrix(
-            (region_image * region.image * 255.999).astype('uint8'),
+            (region_image * region.image * IMAGE_MAX).astype('uint8'),
             [1, 2], [0, np.pi/4, np.pi/2, np.pi*3/4], 256,
             symmetric=True, normed=True)
         glcm[0, :, :, :] = 0

--- a/pyfibre/model/tools/tests/test_base_kmeans_cluster.py
+++ b/pyfibre/model/tools/tests/test_base_kmeans_cluster.py
@@ -36,7 +36,7 @@ class TestKmeansFilter(PyFibreTestCase):
 
         self.assertEqual((10, 10, 3), image_scaled.shape)
         self.assertEqual((10, 10), self.bd_filter._greyscale.shape)
-        self.assertAlmostEqual(224.0, image_scaled.mean())
+        self.assertAlmostEqual(225.0, image_scaled.mean())
 
     def test__cluster_generator(self):
 

--- a/pyfibre/utilities.py
+++ b/pyfibre/utilities.py
@@ -15,9 +15,14 @@ from stevedore import ExtensionManager
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
 SQRT3 = np.sqrt(3)
+
 SQRT2 = np.sqrt(2)
+
 SQRTPI = np.sqrt(np.pi)
+
+IMAGE_MAX = 255.99999
 
 
 class NoiseError(Exception):


### PR DESCRIPTION
Closes #86 

Fixes issue where output images being saved were not normalised. This arose from GUI images needing to be converted to 256 bit, though images being saved as png should contain values from 0-1.