### PR TITLE
[WIP] Add "subtract PL" feature

### DIFF
--- a/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 
 import numpy as np

--- a/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
@@ -22,7 +22,8 @@ class SHGPLTransImage(SHGImage):
     #: Reference to Transmission image
     trans_image = Property(Array, depends_on='image_stack')
 
-    subtract_pl = Bool(False)
+    # FIXME: set to False by default once testing is complete
+    subtract_pl = Bool(True)
 
     _stack_len = 3
 #

--- a/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
@@ -64,6 +64,7 @@ class SHGPLTransImage(SHGImage):
             copy.copy(image) for image in self.image_stack
         ]
         if self.subtract_pl:
+            logger.debug("Applying PL subtraction from SHG channel")
             # Attempt to subtract PL signal from SHG by reducing intensity
             # in pixels proportional to inverse PL strength
             filtered = np.where(

--- a/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/shg_pl_trans_image.py
@@ -1,6 +1,8 @@
 import logging
 
-from traits.api import Array, Property
+import numpy as np
+from skimage import filters
+from traits.api import Array, Bool, Property
 
 from .shg_image import SHGImage
 from .tools.figures import create_shg_pl_trans_figures
@@ -20,8 +22,22 @@ class SHGPLTransImage(SHGImage):
     #: Reference to Transmission image
     trans_image = Property(Array, depends_on='image_stack')
 
+    subtract_pl = Bool(False)
+
     _stack_len = 3
 
+    def _get_shg_image(self):
+        if self.subtract_pl:
+            # Attempt to subtract PL signal from SHG by reducing intensity
+            # in pixels proportional to inverse PL strength
+            filtered = np.where(
+                self.image_stack[1] > 0,
+                (self.image_stack[0] / self.image_stack[1]),
+                self.image_stack[0]
+            )
+            return filters.median(filtered)
+        return self.image_stack[0]
+#
     def _get_pl_image(self):
         return self.image_stack[1]
 

--- a/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
@@ -61,7 +61,7 @@ class TestSHGPLTransImage(TestCase):
                 ]),
                 np.zeros((5, 5))
             ],
-            subtract_pl = True,
+            subtract_pl=True,
         )
 
         np.testing.assert_array_equal(

--- a/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
@@ -49,7 +49,7 @@ class TestSHGPLTransImage(TestCase):
         )
 
     def test_subtract_pl(self):
-        stack = SHGPLTransImage(
+        multi_image = SHGPLTransImage(
             image_stack=[
                 np.ones((5, 5)),
                 np.array([
@@ -62,10 +62,20 @@ class TestSHGPLTransImage(TestCase):
                 np.zeros((5, 5))
             ],
             subtract_pl = True,
-        ).preprocess_images()
+        )
 
         np.testing.assert_array_equal(
-            stack[0],
+            multi_image.shg_image,
+            np.array([
+                [1, 1, 1, 1, 1],
+                [1, 0.5, 0.5, 0.5, 1],
+                [1, 0.5, 0.5, 0.5, 1],
+                [1, 0.5, 0.5, 0.5, 1],
+                [1, 1, 1, 1, 1],
+            ]),
+        )
+        np.testing.assert_array_equal(
+            multi_image.preprocess_images()[0],
             np.array([
                 [1, 1, 1, 1, 1],
                 [1, 0.5, 0.5, 0.5, 1],

--- a/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
@@ -49,7 +49,7 @@ class TestSHGPLTransImage(TestCase):
         )
 
     def test_subtract_pl(self):
-        multi_image = SHGPLTransImage(
+        stack = SHGPLTransImage(
             image_stack=[
                 np.ones((5, 5)),
                 np.array([
@@ -62,15 +62,15 @@ class TestSHGPLTransImage(TestCase):
                 np.zeros((5, 5))
             ],
             subtract_pl = True,
-        )
+        ).preprocess_images()
 
         np.testing.assert_array_equal(
-            multi_image.shg_image,
+            stack[0],
             np.array([
-                [1, 1, 0.5, 1, 1],
-                [1, 1, 0.5, 1, 1],
-                [0.5, 0.5, 0.5, 0.5, 0.5],
-                [1, 1, 0.5, 1, 1],
-                [1, 1, 0.5, 1, 1],
+                [1, 1, 1, 1, 1],
+                [1, 0.5, 0.5, 0.5, 1],
+                [1, 0.5, 0.5, 0.5, 1],
+                [1, 0.5, 0.5, 0.5, 1],
+                [1, 1, 1, 1, 1],
             ]),
         )

--- a/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
+++ b/pyfibre/addons/shg_pl_trans/tests/test_shg_pl_trans_image.py
@@ -47,3 +47,30 @@ class TestSHGPLTransImage(TestCase):
             id(trans_image),
             id(self.multi_image.image_stack[2])
         )
+
+    def test_subtract_pl(self):
+        multi_image = SHGPLTransImage(
+            image_stack=[
+                np.ones((5, 5)),
+                np.array([
+                    [0, 0, 2, 0, 0],
+                    [0, 0, 2, 0, 0],
+                    [2, 2, 2, 2, 2],
+                    [0, 0, 2, 0, 0],
+                    [0, 0, 2, 0, 0],
+                ]),
+                np.zeros((5, 5))
+            ],
+            subtract_pl = True,
+        )
+
+        np.testing.assert_array_equal(
+            multi_image.shg_image,
+            np.array([
+                [1, 1, 0.5, 1, 1],
+                [1, 1, 0.5, 1, 1],
+                [0.5, 0.5, 0.5, 0.5, 0.5],
+                [1, 1, 0.5, 1, 1],
+                [1, 1, 0.5, 1, 1],
+            ]),
+        )


### PR DESCRIPTION
Includes a feature to "subtract" a proportion of the PL signal from the SHG channel during a pre-processing step for SHG-PL-Trans image analysis.

This is estimated (as a first pass) by simply applying a weighting coefficient equal to the the inverse of the PL signal, pixel wise. 

The main aim of this work is to introduce the tooling required to optionally apply - better estimates may be developed at a later date.

### Reviewer notes

In order to facilitate testing, I have simply hard-coded the "subtract PL" feature to always be enabled for the time being.

This work can therefore be tested in an existing PyFibre environment by simply updating the local git clone,
 then navigating to the current branch:

```
git checkout master
git pull
git checkout enh/expose-subtract-pl-feature
```